### PR TITLE
Reflect OS X fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,15 @@ Use this if switching projects is not working:
     "projectManager.codePath": "C:\\Program Files\\Microsoft VS Code\\Bin\\Code.cmd"
 ```
 
-* In **Mac OS X**, first try the same **Windows** approach. If you don't have success, try defining the combination below: 
+* In **Mac OS X**, first make sure `code` is in the PATH. `>Shell Command: Install 'code' command in PATH`.
 
 ```
-    // Define to use the alternative approach
-    "projectManager.useAlternativeMacOSXPath": "true"
-
-    // Then, define the 'Application Name', depending of the channel that you are using
+    // Define the 'Application Name', depending of the channel that you are using
     // - For Code Stable Build, use this:
-    "projectManager.codePath": "com.microsoft.VSCode"
+    "projectManager.codePath": "code"
 
     // - For Code Insider Build, use this:
-    "projectManager.codePath": "com.microsoft.VSCodeInsiders"
+    "projectManager.codePath": "code-insiders"
     
 ```
 
@@ -94,9 +91,6 @@ _(default is `true`)_
 ```
     "projectManager.openInNewWindow": true
 ```
-
-* In Mac OS X, it has no effect _(for now)_, working as `true`.
-
 
 # Changelog
 


### PR DESCRIPTION
Now supports a more direct approach on OS X. Also, openInNewWindow now works.

#13 #14