### PR TITLE
Add commands to activationEvents explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
 		"url": "https://github.com/alefragnani/vscode-project-manager/issues"
 	},
 	"activationEvents": [
-		"*"
+		"*",
+		"onCommand:projectManager.saveProject",
+		"onCommand:projectManager.listProjects",
+		"onCommand:projectManager.listProjectsNewWindow",
+		"onCommand:projectManager.editProjects",
+		"onCommand:projectManager.refreshProjects"
 	],
 	"main": "./out/extension",
 	"contributes": {


### PR DESCRIPTION
You'd think that this shouldn't happen with the wildcard `"*"` `activationEvent`, but I'm often greeted by errors like this when running a project manager command _right after_ opening a VSCode window (so when PM hasn't been loaded yet presumably):

![](http://i.imgur.com/L59zKVT.png)

Adding the command(s) as `activationEvents` explicitly seems to fix this (although there is a slight delay until the quick pick shows up, VSCode probably has to load PM first). Not sure if this is working as designed or if it's a bug in VSCode, but it seems like an OK workaround.