### PR TITLE
Avoid matched projects to be duplicated.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -258,12 +258,22 @@ export function activate(context: vscode.ExtensionContext) {
         });
     }
 
+    // Filters out any newDirectories entries that are present in knownDirectories.
+    function filterKnownDirectories(knownDirectories: any[], newDirectories: any[]): Promise<any[]> {
+        if (knownDirectories) {
+            newDirectories = newDirectories.filter(item => !knownDirectories.some(sortedItem => sortedItem.label === item.name));
+        }
+
+        return Promise.resolve( newDirectories );
+    };
+
     function getVSCodeProjects(itemsSorted: any[], merge: boolean): Promise<{}> {
 
         return new Promise((resolve, reject) => {
 
             vscLocator.locateProjects(vscode.workspace.getConfiguration("projectManager").get("vscode.baseFolders"))
-                .then((dirList) => {
+                .then(filterKnownDirectories.bind(this, merge ? itemsSorted : []))
+                .then((dirList: any[]) => {
                     let newItems = [];
                     newItems = dirList.map(item => {
                         return {
@@ -287,7 +297,8 @@ export function activate(context: vscode.ExtensionContext) {
         return new Promise((resolve, reject) => {
 
             gitLocator.locateProjects(vscode.workspace.getConfiguration("projectManager").get("git.baseFolders"))
-                .then((dirList) => {
+                .then(filterKnownDirectories.bind(this, merge ? itemsSorted : []))
+                .then((dirList: any[]) => {
                     let newItems = [];
                     newItems = dirList.map(item => {
                         return {
@@ -314,7 +325,8 @@ export function activate(context: vscode.ExtensionContext) {
         return new Promise((resolve, reject) => {
 
             svnLocator.locateProjects(vscode.workspace.getConfiguration("projectManager").get("svn.baseFolders"))
-                .then((dirList) => {
+                .then(filterKnownDirectories.bind(this, merge ? itemsSorted : []))
+                .then((dirList: any[]) => {
                     let newItems = [];
                     newItems = dirList.map(item => {
                         return {


### PR DESCRIPTION
This PR fixes #89.

Actually this one required some more fun. I added filtering as an additional promise step.

It was important to filter on `dirList` rather than `newItems`, because `newItems` are [working with modified label](https://github.com/mlewand/vscode-project-manager/blob/75fa286/extension.ts#L305) - with extra prefixes.

Note that filtering is performed only when `merge` variable is set, because by definition if you're not merging you want to get unfiltered list.