### PR TITLE
Add .haxelib to default list of ignored folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
 						"node_modules",
 						"out",
 						"typings",
-						"test"
+						"test",
+						".haxelib"
 					],
 					"description": "Indicates folders to be ignored, like \"node_modules\", \"out\", \"typings\", \"test\""
 				},


### PR DESCRIPTION
`.haxelib` is the `node_modules` equivalent of Haxe's package manager, Haxelib. Naturally, you wouldn't want projects in there to be picked up.