### PR TITLE
Fixed extension not working if the VSCode folder was called "Code - OSS"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -592,13 +592,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     function getChannelPath(): string {
-        if (vscode.env.appName.indexOf("Insiders") > 0) {
-            return "Code - Insiders";
-        } else if (vscode.env.appName.indexOf("OSS") > 0) {
-            return "Code - OSS";
-        } else {
-            return "Code";
-        }
+        return vscode.env.appName.replace("Visual Studio ", "");
     }
 
     function loadProjectsFile() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -594,6 +594,8 @@ export function activate(context: vscode.ExtensionContext) {
     function getChannelPath(): string {
         if (vscode.env.appName.indexOf("Insiders") > 0) {
             return "Code - Insiders";
+        } else if (vscode.env.appName.indexOf("OSS") > 0) {
+            return "Code - OSS";
         } else {
             return "Code";
         }


### PR DESCRIPTION
Basically added an extra if statement when checking the value of vscode.env.appName, so if it has "OSS" on it, the path will be changed to `Code - OSS` instead of `Code`, which was conflicting before making the extension unable to work.