### PR TITLE
Add ability to temporarily disable individual projects (#154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,30 @@ For easier customization of your project list, you can edit the `projects.json` 
         "name": "Pascal MI",
         "rootPath": "c:\\PascalProjects\\pascal-menu-insight",
         "paths": [],
-        "group": ""
+        "group": "",
+        "enabled": true
     },
     {
         "name": "Bookmarks",
         "rootPath": "$home\\Documents\\GitHub\\vscode-bookmarks",
         "paths": [],
-        "group": ""
+        "group": "",
+        "enabled": true
     },
     {
         "name": "Numbered Bookmarks",
         "rootPath": "$home\\Documents\\GitHub\\vscode-numbered-bookmarks",
         "paths": [],
-        "group": ""
+        "group": "",
+        "enabled": false
     }
 ]
 ```
 
-> For now, only `name` and `rootPath` fields are used. 
-> Use a special variable called `$home` while defining any `path`. It will be replaced by the HOME folder.  
+For now, only `name`, `rootPath`, and `enabled` fields are used.
+> Use a special variable called `$home` while defining any `path`. It will be replaced by the HOME folder.
+
+> Projects that are *not* `enabled` will be hidden from project listings until re-enabled.
 
 > Be sure that the JSON file is well-formed. Otherwise, **Project Manager** will not be able to open it, and an error message like this should appear. In this case, you should use the `Open File` button to fix it.
 

--- a/package.json
+++ b/package.json
@@ -130,6 +130,10 @@
 			{
 				"command": "projectManager.renameProject",
 				"title": "Rename Project"
+			},
+			{
+				"command": "projectManager.toggleProjectEnabled",
+				"title": "Disable Project"
 			}
 		],
 		"menus": {
@@ -185,6 +189,11 @@
 				},
 				{
 					"command": "projectManager.renameProject",
+					"when": "view == projectsExplorerFavorites",
+					"group": "favorites"
+				},
+				{
+					"command": "projectManager.toggleProjectEnabled",
 					"when": "view == projectsExplorerFavorites",
 					"group": "favorites"
 				}

--- a/src/abstractLocator.ts
+++ b/src/abstractLocator.ts
@@ -217,7 +217,8 @@ export class CustomProjectLocator {
                     rootPath: element.fullPath,
                     name: element.name,
                     group: "",
-                    paths: [] 
+                    paths: [],
+                    enabled: true
                 };
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("projectManager.addToWorkspace", (node) => addProjectToWorkspace(node));
     vscode.commands.registerCommand("projectManager.deleteProject", (node) => deleteProject(node));
     vscode.commands.registerCommand("projectManager.renameProject", (node) => renameProject(node));
+    vscode.commands.registerCommand("projectManager.toggleProjectEnabled", (node) => toggleProjectEnabled(node));
 
     loadProjectsFile();
 
@@ -586,4 +587,27 @@ export function activate(context: vscode.ExtensionContext) {
         });
     };
 
+    function toggleProjectEnabled(node: any) {
+        const enabled = projectStorage.toggleEnabled(node.command.arguments[1]);
+        
+        if (enabled == undefined) {
+            return;
+        }
+
+        projectStorage.save();
+        if (enabled) {
+            vscode.window.showInformationMessage("Project enabled.", "Undo").then(undo => {
+                if (undo) {
+                    toggleProjectEnabled(node);
+                }
+            });;
+        } else {
+            vscode.window.showInformationMessage("Project disabled.", "Undo").then(undo => {
+                if (undo) {
+                    toggleProjectEnabled(node);
+                }
+            });
+        }
+            
+    };
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -87,6 +87,22 @@ export class ProjectStorage {
             }
         }
     }
+    
+    /**
+     * Toggle the enabled property of a project
+     * 
+     * @param `name` The [Project Name](#Project.name)
+     *
+     * @return If the project is *now* enabled (or `undefined` if not found)
+     */
+    public toggleEnabled(name: string): boolean | undefined {
+        for (const element of this.projectList) {
+            if (element.name.toLowerCase() === name.toLowerCase()) {
+                element.enabled = !element.enabled;
+                return element.enabled;
+            }
+        }
+    }
 
     /**
      * Adds another `path` to a project

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -8,6 +8,7 @@ export interface Project {
   rootPath: string; // the root path of this project
   paths: string[];  // the 'other paths' when you have multifolder project
   group: string;    // the group(s) that it belongs to
+  enabled: boolean; // the project should be displayed in the project list
 };
 
 export interface ProjectList extends Array<Project> {};
@@ -18,12 +19,14 @@ class ProjectItem implements Project {
     public rootPath: string; // the root path of this project
     public paths: string[];  // the 'other paths' when you have multifolder project
     public group: string;    // the group(s) that it belongs to
+    public enabled: boolean; // the project should be displayed in the project list
 
     constructor(pname: string, prootPath: string) {
         this.name = pname;
         this.rootPath = prootPath;
         this.paths = [];
         this.group = "";
+        this.enabled = true;
     }
 }
 
@@ -204,7 +207,7 @@ export class ProjectStorage {
      *         An **empty string** if everything is ok.
      */
     public load(): string {
-        let items = [];
+        let items: Array<any> = [];
 
         // missing file (new install)
         if (!fs.existsSync(this.filename)) {
@@ -222,7 +225,14 @@ export class ProjectStorage {
                 // save updated
                 this.save();
             } else { // NEW format
-                this.projectList = items as ProjectList;
+                this.projectList = (items as Array<Partial<Project>>).map(item => ({
+                    name: '',
+                    rootPath: '',
+                    paths: [],
+                    group: '',
+                    enabled: true,
+                    ...item
+                }));
             }
 
             this.updatePaths();
@@ -267,7 +277,7 @@ export class ProjectStorage {
      * @return A list of projects `{[label, description]}` to be used on a `showQuickPick`
      */    
     public map(): any {
-        const newItems = this.projectList.map(item => {
+        const newItems = this.projectList.filter(item => item.enabled).map(item => {
             return {
               label: item.name,
               description: item.rootPath  


### PR DESCRIPTION
This is an initial implementation that requires manual editing of the
config. Future enhancements could include commands to enable/disable
the current (or a selected) project.

It maintains backwards compatibility with the existing storage format by
setting the default value to `true`.  It also provides default values
for all other properties of a `Project`, but they may not *really* be
valid (e.g. an empty string for name). It could be improved by actually
validating the loaded data and handling invalid entries (just ignore
them, probably?).