### PR TITLE
Add option to ignore Git submodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,6 +338,11 @@
 					"default": [],
 					"description": "Indicates the base folders to search for Git projects"
 				},
+				"projectManager.git.ignoreSubmodules": {
+					"type": "boolean",
+					"default": false,
+					"description": "Indicates whether to ignore Git submodules"
+				},
 				"projectManager.git.ignoredFolders": {
 					"type": "array",
 					"default": [

--- a/src/abstractLocator.ts
+++ b/src/abstractLocator.ts
@@ -15,9 +15,9 @@ export interface DirList extends Array<DirInfo> { };
 
 export interface RepositoryDetector {
 
-    isRepoDir(projectPath: string);
+    isRepoDir(projectPath: string, dirList: DirList): boolean;
     decideProjectName(projectPath: string): string; 
-
+    refreshConfig();
 }
 
 export class CustomRepositoryDetector implements RepositoryDetector {
@@ -25,7 +25,11 @@ export class CustomRepositoryDetector implements RepositoryDetector {
     constructor(public paths: string[]) {
     }
 
-    public isRepoDir(projectPath: string) {
+    public refreshConfig() {
+        //
+    }
+
+    public isRepoDir(projectPath: string, dirList: DirList) {
         return fs.existsSync(path.join(projectPath, ...this.paths));
     }
 
@@ -168,7 +172,7 @@ export class CustomProjectLocator {
 
     public processDirectory = (absPath: string, stat: any) => {
         // vscode.window.setStatusBarMessage(absPath, 600);
-        if (this.repositoryDetector.isRepoDir(absPath)) {
+        if (this.repositoryDetector.isRepoDir(absPath, this.dirList)) {
             this.addToList(absPath, this.repositoryDetector.decideProjectName(absPath));
         }
     }
@@ -270,6 +274,8 @@ export class CustomProjectLocator {
             this.useCachedProjects = currentValue;
             refreshedSomething = true;
         }
+
+        this.repositoryDetector.refreshConfig();
 
         return refreshedSomething;
     }

--- a/src/gitLocator.ts
+++ b/src/gitLocator.ts
@@ -1,13 +1,40 @@
 import fs = require("fs");
 import path = require("path");
-import { CustomRepositoryDetector } from "./abstractLocator";
+import vscode = require("vscode");
+import { CustomRepositoryDetector, DirList } from "./abstractLocator";
 
 export class GitRepositoryDetector extends CustomRepositoryDetector {
+    private ignoreGitSubmodules: boolean;
 
-    public isRepoDir(projectPath: string) {
+    constructor(public paths: string[]) {
+        super(paths);
+
+        this.ignoreGitSubmodules = false;
+        this.refreshConfig();
+    }
+
+    public refreshConfig(): boolean {
+        const config = vscode.workspace.getConfiguration("projectManager");
+        let refreshedSomething: boolean = false;
+        let currentValue = null;
+
+        currentValue = config.get("git.ignoreSubmodules", false);
+        if (this.ignoreGitSubmodules !== currentValue) {
+            this.ignoreGitSubmodules = currentValue;
+            refreshedSomething = true;
+        }
+
+        return refreshedSomething;
+    }
+
+    public isRepoDir(projectPath: string, dirList: DirList) {
         let isGit: boolean;
         isGit = fs.existsSync(path.join(projectPath, ".git", "config"));
         if (isGit) {
+            if (this.ignoreSubmodule(projectPath, dirList)) {
+                return false;
+            }
+
             return true;
         }
 
@@ -18,14 +45,29 @@ export class GitRepositoryDetector extends CustomRepositoryDetector {
                 file = fs.readFileSync(path.join(projectPath, ".git"), "utf8");
                 isGit = file.indexOf("gitdir: ") === 0;
                 if (isGit) {
+                    if (this.ignoreSubmodule(projectPath, dirList)) {
+                        return false;
+                    }
+
                     return true;
                 }
             } catch (e) {
                 console.log("Error checking git-worktree: " + e);
             }
         }
-        
+
         return false;
     }
 
+    private ignoreSubmodule(projectPath: string, dirList: DirList): boolean {
+        if (this.ignoreGitSubmodules) {
+            for (const dir of dirList) {
+                if (projectPath.startsWith(dir.fullPath)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Fix #189 - adds an option to ignore Git submodules (or other Git projects under an existing project)

Basically when traversing the tree if a Git path is a child of an already-detected Git path it will be ignored.