### PR TITLE
Use vscode.ExtensionContext.globalStoragePath to determine location to persist extension data

### DIFF
--- a/src/PathUtils.ts
+++ b/src/PathUtils.ts
@@ -150,9 +150,10 @@ export class PathUtils {
         let appdata: string;
         const channelPath: string = this.getChannelPath();
         let newFile: string;
-        if (extensionStoragePath !== "") {
-            newFile = path.join(extensionStoragePath, file);
-        } else if (process.env.VSCODE_PORTABLE) {
+        // Original logic to find path. We will only use this path
+        // if a file already exists in this location or we are on
+        // an old version of VS Code.
+        if (process.env.VSCODE_PORTABLE) {
             appdata = process.env.VSCODE_PORTABLE;
             newFile = path.join(appdata, channelPath, "User", file);
         } else {
@@ -161,6 +162,14 @@ export class PathUtils {
             // in linux, it may not work with /var/local, then try to use /home/myuser/.config
             if ((process.platform === "linux") && (!fs.existsSync(newFile))) {
                 newFile = path.join(homeDir, ".config/", channelPath, "User", file);
+            }
+        }
+        // If we are on a new version of VS Code, use the specified
+        // global extension storage path unless a file exists in 
+        // the old location.
+        if (extensionStoragePath !== "") {
+            if (!fs.existsSync(newFile)) {
+                newFile = path.join(extensionStoragePath, file);
             }
         }
         return newFile;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,9 @@ const anyLocator: CustomProjectLocator = new CustomProjectLocator("any", "Any", 
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
+    // Sets storage path if recommended path provided by current version of VS Code.  
+    PathUtils.setExtensionContext(context);
+
     const recentProjects: string = context.globalState.get<string>("recent", "");
     const aStack: stack.StringStack = new stack.StringStack();
     aStack.fromString(recentProjects);


### PR DESCRIPTION
Recent versions of VS Code now have a `globalStoragePath` property on the `vscode.ExtensionContext` object passed into the activation method of the extension.  Using this path instead of manually forming one to use to persist data reduces the chances of unexpected issues with future VS Code updates (e.g. if folder paths change, new VS Code flavors are released, etc).

This PR updates PathUtils to detect if this property is available on the ExtensionContext object passed into the activation event and uses it if so. If not found, it falls back to the existing logic.