### PR TITLE
Default to running locally with remote development

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
 		"git",
 		"multi-root ready"
 	],
+	"extensionKind": [
+		"ui",
+		"workspace"
+	],
 	"icon": "images/icon.png",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"homepage": "https://github.com/alefragnani/vscode-project-manager/blob/master/README.md",


### PR DESCRIPTION
closes #284

When you have a remote workspace open, you will suddenly notice that the project manager commands are no longer working. This is because VSCode defaults to running extensions on the remote / as a "workspace" extension: https://code.visualstudio.com/docs/remote/faq#_can-an-extension-access-local-resources-or-apis-when-a-user-is-connected-remotely

This fixes this by changing the default to `"ui"`, so Project Manager runs locally. I'm not sure it makes much sense to run Project Manager remotely, but having it in the `"extensionKind"` array still allows for this.
