### PR TITLE
add git clone btn to projects explorer view

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
 				},
 				{
 				    	"command": "git.clone",
-				    	"when": "view =~ /(projectsExplorerVSCode|projectsExplorerGit|projectsExplorerSVN|projectsExplorerAny|projectsExplorerMercurial)/",
+				    	"when": "view == projectsExplorerGit",
 				    	"group": "navigation"
 				},
 			],

--- a/package.json
+++ b/package.json
@@ -252,7 +252,12 @@
 			{
 				"command": "projectManager.supportProjectManager",
 				"title": "%projectManager.commands.supportProjectManager.title%"
-			}
+			},
+			{
+				"command": "git.clone",
+				"title": "Clone Repo",
+				"icon": "$(repo-clone)"
+		    	},
 		],
 		"menus": {
 			"commandPalette": [
@@ -395,7 +400,12 @@
 					"command": "projectManager.openSettings#sideBarMercurial",
 					"when": "view == projectsExplorerMercurial",
 					"group": "2_projectManager"
-				}
+				},
+				{
+				    	"command": "git.clone",
+				    	"when": "view =~ /(projectsExplorerVSCode|projectsExplorerGit|projectsExplorerSVN|projectsExplorerAny|projectsExplorerMercurial)/",
+				    	"group": "navigation"
+				},
 			],
 			"view/item/context": [
 				{


### PR DESCRIPTION
for quicker adding new projects instead of going to the scm panel to clone first.