### PR TITLE
Correct spelling of setting with typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ If you intend to _share_ projects between  **Stable** and **Insider** installati
   * `never`: Works as today. The Open in New Window command will always open in New Window
 
 ```json 
-    "projectManager.openInCurrenWindowIfEmpty": "always"
+    "projectManager.openInCurrentWindowIfEmpty": "always"
 ```
 
 * Indicates the list of tags you can use to organize your projects _(`Personal` and `Work` by default)_

--- a/package.json
+++ b/package.json
@@ -800,7 +800,7 @@
 					"default": false,
 					"description": "%projectManager.configuration.filterOnFullPath.description%"
 				},
-				"projectManager.openInCurrenWindowIfEmpty": {
+				"projectManager.openInCurrentWindowIfEmpty": {
 					"type": "string",
 					"default": "always",
 					"enum": [
@@ -815,7 +815,7 @@
 						"Only open in the current window if you use the Side Bar",
 						"Works as today. The Open in New Window command will always open in New Window"
 					],
-					"description": "%projectManager.configuration.openInCurrenWindowIfEmpty.description%"
+					"description": "%projectManager.configuration.openInCurrentWindowIfEmpty.description%"
 				},
                 "projectManager.tags": {
                     "type": "array",

--- a/package.nls.cs.json
+++ b/package.nls.cs.json
@@ -69,6 +69,6 @@
     "projectManager.configuration.checkInvalidPathsBeforeListing.description": "Před výpisem zkontrolovat neplatné cesty a zobrazit zprávu pod názvem projektu?",
     "projectManager.configuration.supportSymlinksOnBaseFolders.description": "Měly by podporovat symbolické odkazy na `baseFolders`?",
     "projectManager.configuration.filterOnFullPath.description": "Filtrovat projekty celou cestou?",
-    "projectManager.configuration.openInCurrenWindowIfEmpty.description": "Označuje, zda příkaz \"Nové okno\" otevře projekt v aktuálním okně, je-li prázdný.",
+    "projectManager.configuration.openInCurrentWindowIfEmpty.description": "Označuje, zda příkaz \"Nové okno\" otevře projekt v aktuálním okně, je-li prázdný.",
     "projectManager.configuration.tags.description": "Označuje seznam značek, které můžete použít k uspořádání projektů"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -70,6 +70,6 @@
     "projectManager.configuration.supportSymlinksOnBaseFolders.description": "Should support symlinks on `baseFolders`?",
     "projectManager.configuration.showParentFolderInfoOnDuplicates.description": "Should show the parent folder info when projects with same name are detected?",
     "projectManager.configuration.filterOnFullPath.description": "Should filter projects through full path?",
-    "projectManager.configuration.openInCurrenWindowIfEmpty.description": "Indicates if the New Window command open the project in current window, when empty.",
+    "projectManager.configuration.openInCurrentWindowIfEmpty.description": "Indicates if the New Window command open the project in current window, when empty.",
     "projectManager.configuration.tags.description": "Indicates the list of tags you can use to organize your projects"
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -69,6 +69,6 @@
     "projectManager.configuration.checkInvalidPathsBeforeListing.description": "Controla se deve verificar por pastas inválidas antes de listá-las, apresentando uma mensagem abaixo do nome do projeto",
     "projectManager.configuration.supportSymlinksOnBaseFolders.description": "Controla se deve suportar links simbólicos em `baseFolders`?",
     "projectManager.configuration.filterOnFullPath.description": "Controla se deve filtrar projetos pelo caminho completo",
-    "projectManager.configuration.openInCurrenWindowIfEmpty.description": "Indica se o comando Nova Janela abre o projeto na janela corrente, quando vazia",
+    "projectManager.configuration.openInCurrentWindowIfEmpty.description": "Indica se o comando Nova Janela abre o projeto na janela corrente, quando vazia",
     "projectManager.configuration.tags.description": "Indica a lista de etiquetas que você pode usar para organizar seus projetos"
 }

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -69,6 +69,6 @@
     "projectManager.configuration.checkInvalidPathsBeforeListing.description": "Следует ли проверять наличие недопустимых путей перед выводом списка, показывая сообщение под именем проекта?",
     "projectManager.configuration.supportSymlinksOnBaseFolders.description": "Должны ли поддерживаться символические ссылки на `baseFolders`?",
     "projectManager.configuration.filterOnFullPath.description": "Следует ли фильтровать проекты по полному пути?",
-    "projectManager.configuration.openInCurrenWindowIfEmpty.description": "Указывает, открывает ли команда «Новое окно» проект в текущем пустом окне.",
+    "projectManager.configuration.openInCurrentWindowIfEmpty.description": "Указывает, открывает ли команда «Новое окно» проект в текущем пустом окне.",
     "projectManager.configuration.tags.description": "Указывает список тегов, которые вы можете использовать для организации ваших проектов."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -69,6 +69,6 @@
     "projectManager.configuration.checkInvalidPathsBeforeListing.description": "列出之前是否应该检查无效路径，并在项目名称下方显示一条消息？",
     "projectManager.configuration.supportSymlinksOnBaseFolders.description": "应该支持“baseFolders”上的符号链接吗？",
     "projectManager.configuration.filterOnFullPath.description": "是否应该通过完整路径过滤项目？",
-    "projectManager.configuration.openInCurrenWindowIfEmpty.description": "当本窗口为空时，执行在新窗口中打开项目的命令后是否应该打开新窗口？",
+    "projectManager.configuration.openInCurrentWindowIfEmpty.description": "当本窗口为空时，执行在新窗口中打开项目的命令后是否应该打开新窗口？",
     "projectManager.configuration.tags.description": "表示可用于组织项目的标签列表"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -365,7 +365,9 @@ export function activate(context: vscode.ExtensionContext) {
             return openInNewWindow;
         }
 
-        const config = vscode.workspace.getConfiguration("projectManager").get<string>("openInCurrentWindowIfEmpty");
+        // Check for setting name before and after typo was corrected
+        const config = vscode.workspace.getConfiguration("projectManager").get<string>("openInCurrenWindowIfEmpty")
+            || vscode.workspace.getConfiguration("projectManager").get<string>("openInCurrentWindowIfEmpty");
         if (config === OpenInCurrentWindowIfEmptyMode.always) {
             return false;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -365,7 +365,7 @@ export function activate(context: vscode.ExtensionContext) {
             return openInNewWindow;
         }
 
-        const config = vscode.workspace.getConfiguration("projectManager").get<string>("openInCurrenWindowIfEmpty");
+        const config = vscode.workspace.getConfiguration("projectManager").get<string>("openInCurrentWindowIfEmpty");
         if (config === OpenInCurrentWindowIfEmptyMode.always) {
             return false;
         }


### PR DESCRIPTION
Corrected spelling of the word `current` in the `openInCurrentWindowIfEmpty` setting. 