### PR TITLE
"List Projects to open" - filter on full path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -438,7 +438,7 @@ export function activate(context: vscode.ExtensionContext) {
 
             const options = <vscode.QuickPickOptions> {
                 matchOnDescription: vscode.workspace.getConfiguration("projectManager").get("filterOnFullPath", false),
-                matchOnDetail: false,
+                matchOnDetail: true,
                 placeHolder: "Loading Projects (pick one...)"
             };
     


### PR DESCRIPTION
When filtering for projects in the "List Projects to open" fild, the project path should be incorporated. This is helpful when there are lots of equally named projects under different paths.
Would that patch solve that requirement?