### PR TITLE
docs: add `workbench.action.quickOpenSelectPrevious` command key binding to keyboard focused users section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,24 @@ Just use the `when` clause `"inProjectManagerList"`, like:
 
 ```json
     {
+        "key": "cmd+j",
+        "command": "workbench.action.quickOpenSelectNext",
+        "when": "inProjectManagerList && isMac"
+    },
+    {
+        "key": "cmd+shift+j",
+        "command": "workbench.action.quickOpenSelectPrevious",
+        "when": "inProjectManagerList && isMac"
+    },
+    {
         "key": "ctrl+j",
         "command": "workbench.action.quickOpenSelectNext",
-        "when": "inProjectManagerList"
+        "when": "inProjectManagerList && (isWindows || isLinux)"
     },
     {
         "key": "ctrl+shift+j",
         "command": "workbench.action.quickOpenSelectPrevious",
-        "when": "inProjectManagerList"
+        "when": "inProjectManagerList && (isWindows || isLinux)"
     }
 ```
 


### PR DESCRIPTION
This PR adds <kbd>ctrl+shift+j</kbd> key binding for `workbench.action.quickOpenSelectPrevious` to the "Keyboard Focused Users" section in the README to match VSCode's native quick open navigation pattern. This creates symmetric keyboard controls (<kbd>ctrl+j</kbd>/<kbd>ctrl+shift+j</kbd>) similar to other VSCode commands like <kbd>ctrl+p</kbd>/<kbd>ctrl+shift+p</kbd>, providing a familiar experience for keyboard-focused users when navigating project lists with the `inProjectManagerList` context. This also includes examples for different operating systems.