### PR TITLE
Add hierarchical sub-tags support with :: separator (#689)

### DIFF
--- a/src/sidebar/nodes.ts
+++ b/src/sidebar/nodes.ts
@@ -103,9 +103,16 @@ export class TagNode extends TreeItem {
     constructor(
         public readonly label: string,
         public readonly collapsibleState: TreeItemCollapsibleState,
+        public readonly fullPath?: string,
+        public readonly parentPath?: string
     ) {
         super(label, collapsibleState);
         this.iconPath = ThemeIcons.tag;
+        this.contextValue = "TagNodeKind";
+    }
+
+    public getTagId(): string {
+        return this.fullPath ?? this.label;
     }
 }
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -9,6 +9,7 @@ import { isRemotePath } from "../utils/remote";
 import { Uri } from "vscode";
 import { createProject, Project } from "../core/project";
 import { NO_TAGS_DEFINED } from "../sidebar/constants";
+import { tagMatchesFilter } from "../utils/tagHierarchy";
 
 export class ProjectStorage {
 
@@ -200,10 +201,20 @@ export class ProjectStorage {
     public getProjectsByTags(tags: string[]): any {
         const newItems = this.projects.filter(
             item => item.enabled
-                && (item.tags.some(t => tags.includes(t))
-                    || ((tags.length === 0 || tags.includes(NO_TAGS_DEFINED) && item.tags.length === 0)
-                    ))
+                && (item.tags.some(projectTag => tags.some(filterTag => tagMatchesFilter(projectTag, filterTag)))
+                    || ((tags.length === 0 || tags.includes(NO_TAGS_DEFINED)) && item.tags.length === 0))
         ).map(item => {
+            return {
+                label: item.name,
+                description: item.rootPath,
+                profile: item.profile
+            };
+        });
+        return newItems;
+    }
+
+    public getProjectsByTagExact(tag: string): any {
+        const newItems = this.projects.filter(item => item.enabled && item.tags.includes(tag)).map(item => {
             return {
                 label: item.name,
                 description: item.rootPath,

--- a/src/test/suite/tagHierarchy.test.ts
+++ b/src/test/suite/tagHierarchy.test.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import {
+    parseTagHierarchy,
+    getParentTag,
+    isChildTag,
+    tagMatchesFilter,
+    TAG_SEPARATOR
+} from "../../utils/tagHierarchy";
+
+suite("Tag Hierarchy Tests", () => {
+
+    suite("parseTagHierarchy", () => {
+        test("should parse flat tags", () => {
+            const tags = ["Work", "Personal", "TypeScript"];
+            const hierarchy = parseTagHierarchy(tags);
+
+            assert.strictEqual(hierarchy.size, 3);
+            assert.ok(hierarchy.has("Work"));
+            assert.ok(hierarchy.has("Personal"));
+            assert.ok(hierarchy.has("TypeScript"));
+        });
+
+        test("should parse hierarchical tags", () => {
+            const tags = ["Work::Completed", "Work::InProgress"];
+            const hierarchy = parseTagHierarchy(tags);
+
+            assert.strictEqual(hierarchy.size, 1);
+            assert.ok(hierarchy.has("Work"));
+
+            const workNode = hierarchy.get("Work")!;
+            assert.strictEqual(workNode.children.size, 2);
+            assert.ok(workNode.children.has("Completed"));
+            assert.ok(workNode.children.has("InProgress"));
+        });
+
+        test("should parse deeply nested tags", () => {
+            const tags = ["Work::InProgress::Frontend"];
+            const hierarchy = parseTagHierarchy(tags);
+
+            const workNode = hierarchy.get("Work")!;
+            assert.strictEqual(workNode.fullPath, "Work");
+
+            const inProgressNode = workNode.children.get("InProgress")!;
+            assert.strictEqual(inProgressNode.fullPath, "Work::InProgress");
+
+            const frontendNode = inProgressNode.children.get("Frontend")!;
+            assert.strictEqual(frontendNode.fullPath, "Work::InProgress::Frontend");
+        });
+
+        test("should handle mixed flat and hierarchical tags", () => {
+            const tags = ["Work::Completed", "Personal", "Work::InProgress::Frontend"];
+            const hierarchy = parseTagHierarchy(tags);
+
+            assert.strictEqual(hierarchy.size, 2);
+            assert.ok(hierarchy.has("Work"));
+            assert.ok(hierarchy.has("Personal"));
+
+            const personalNode = hierarchy.get("Personal")!;
+            assert.strictEqual(personalNode.children.size, 0);
+        });
+
+        test("should handle empty array", () => {
+            const hierarchy = parseTagHierarchy([]);
+            assert.strictEqual(hierarchy.size, 0);
+        });
+    });
+
+    suite("getParentTag", () => {
+        test("should return undefined for flat tag", () => {
+            assert.strictEqual(getParentTag("Work"), undefined);
+        });
+
+        test("should return parent for nested tag", () => {
+            assert.strictEqual(getParentTag("Work::Completed"), "Work");
+        });
+
+        test("should return immediate parent for deeply nested tag", () => {
+            assert.strictEqual(getParentTag("Work::InProgress::Frontend"), "Work::InProgress");
+        });
+    });
+
+    suite("isChildTag", () => {
+        test("should return false for same tag", () => {
+            assert.strictEqual(isChildTag("Work", "Work"), false);
+        });
+
+        test("should return true for direct child", () => {
+            assert.strictEqual(isChildTag("Work", "Work::Completed"), true);
+        });
+
+        test("should return true for deeply nested child", () => {
+            assert.strictEqual(isChildTag("Work", "Work::InProgress::Frontend"), true);
+        });
+
+        test("should return false for unrelated tags", () => {
+            assert.strictEqual(isChildTag("Work", "Personal"), false);
+        });
+
+        test("should return false for partial match", () => {
+            assert.strictEqual(isChildTag("Work", "WorkCompleted"), false);
+        });
+    });
+
+    suite("tagMatchesFilter", () => {
+        test("should match exact tag", () => {
+            assert.strictEqual(tagMatchesFilter("Work", "Work"), true);
+        });
+
+        test("should match child tag when filtering by parent", () => {
+            assert.strictEqual(tagMatchesFilter("Work::Completed", "Work"), true);
+        });
+
+        test("should match deeply nested child", () => {
+            assert.strictEqual(tagMatchesFilter("Work::InProgress::Frontend", "Work"), true);
+        });
+
+        test("should not match parent when filtering by child", () => {
+            assert.strictEqual(tagMatchesFilter("Work", "Work::Completed"), false);
+        });
+
+        test("should not match unrelated tags", () => {
+            assert.strictEqual(tagMatchesFilter("Personal", "Work"), false);
+        });
+    });
+
+    suite("TAG_SEPARATOR constant", () => {
+        test("should be '::'", () => {
+            assert.strictEqual(TAG_SEPARATOR, "::");
+        });
+    });
+});

--- a/src/utils/tagHierarchy.ts
+++ b/src/utils/tagHierarchy.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+export const TAG_SEPARATOR = "::";
+
+export interface TagHierarchyNode {
+    name: string;
+    fullPath: string;
+    children: Map<string, TagHierarchyNode>;
+}
+
+export function parseTagHierarchy(tags: string[]): Map<string, TagHierarchyNode> {
+    const root = new Map<string, TagHierarchyNode>();
+
+    for (const tag of tags) {
+        const parts = tag.split(TAG_SEPARATOR);
+        let currentLevel = root;
+        let currentPath = "";
+
+        for (const part of parts) {
+            currentPath = currentPath ? `${currentPath}${TAG_SEPARATOR}${part}` : part;
+
+            if (!currentLevel.has(part)) {
+                currentLevel.set(part, {
+                    name: part,
+                    fullPath: currentPath,
+                    children: new Map()
+                });
+            }
+
+            currentLevel = currentLevel.get(part)!.children;
+        }
+    }
+
+    return root;
+}
+
+export function getParentTag(tag: string): string | undefined {
+    const lastSeparatorIndex = tag.lastIndexOf(TAG_SEPARATOR);
+    if (lastSeparatorIndex === -1) {
+        return undefined;
+    }
+    return tag.substring(0, lastSeparatorIndex);
+}
+
+export function getTagParts(tag: string): string[] {
+    return tag.split(TAG_SEPARATOR);
+}
+
+export function getLeafTagName(tag: string): string {
+    const parts = tag.split(TAG_SEPARATOR);
+    return parts[parts.length - 1];
+}
+
+export function isChildTag(parentTag: string, childTag: string): boolean {
+    if (parentTag === childTag) {
+        return false;
+    }
+    return childTag.startsWith(parentTag + TAG_SEPARATOR);
+}
+
+export function tagMatchesFilter(tag: string, filterTag: string): boolean {
+    return tag === filterTag || isChildTag(filterTag, tag);
+}
+
+


### PR DESCRIPTION
- Add tag hierarchy parsing utility for :: separated tags
- Update sidebar tree view to render nested tag structure
- Projects appear only under their most specific tag node
- Filtering by parent tag includes all child tag projects
- Add getProjectsByTagExact() for leaf node project display
- Add comprehensive tests for tag hierarchy functions