### PR TITLE
Add alwaysOpenInNewWindow configuration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -708,6 +708,11 @@
 						"default": false,
 						"description": "%projectManager.configuration.openInNewWindowWhenClickingInStatusBar.description%"
 					},
+					"projectManager.alwaysOpenInNewWindow": {
+						"type": "boolean",
+						"default": false,
+						"description": "Always open projects in a new window instead of the current one."
+					},
 					"projectManager.removeCurrentProjectFromList": {
 						"type": "boolean",
 						"default": true,

--- a/src/quickpick/projectsPicker.ts
+++ b/src/quickpick/projectsPicker.ts
@@ -205,6 +205,10 @@ export async function pickProjects(projectStorage: ProjectStorage, locators: Loc
 }
 
 export function shouldOpenInNewWindow(openInNewWindow: boolean, calledFrom: CommandLocation): boolean {
+    if (workspace.getConfiguration("projectManager").get<boolean>("alwaysOpenInNewWindow", false)) {
+        return true;
+    }
+
     if (!openInNewWindow) {
         return false;
     }


### PR DESCRIPTION
When enabled, projects always open in a new window regardless of other settings. Adds a check at the top of shouldOpenInNewWindow() that reads the new projectManager.alwaysOpenInNewWindow boolean config.