### PR TITLE
Fix Remote SSH project matching by authority

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -104,7 +104,7 @@ export class ProjectStorage {
             if (!isRemotePath(element.rootPath)) { continue; }
 
             const uriElement = Uri.parse(element.rootPath);
-            if (uriElement.path === uri.path) {
+            if (uriElement.scheme === uri.scheme && uriElement.authority === uri.authority && uriElement.path === uri.path) {
                 return element;
             }
         }

--- a/src/test/suite/storage.test.ts
+++ b/src/test/suite/storage.test.ts
@@ -226,9 +226,43 @@ suite("ProjectStorage", () => {
         const uri = Uri.parse(remoteRoot);
         const found = storage.existsRemoteWithRootPath(uri);
 
-        // Implementation matches by path, not full URI
         assert.ok(found);
         assert.strictEqual(found!.name, "RemoteProject");
+    });
+
+    test("existsRemoteWithRootPath uses the remote URI authority when matching", () => {
+        const filename = createTempFilename();
+        const storage = new ProjectStorage(filename);
+
+        storage.push("RemoteA", "vscode-remote://ssh-remote+server-A/home/user/project");
+        storage.push("RemoteB", "vscode-remote://ssh-remote+server-B/home/user/project");
+
+        const found = storage.existsRemoteWithRootPath(Uri.parse("vscode-remote://ssh-remote+server-B/home/user/project"));
+
+        assert.ok(found);
+        assert.strictEqual(found!.name, "RemoteB");
+    });
+
+    test("existsRemoteWithRootPath ignores same path on a different remote authority", () => {
+        const filename = createTempFilename();
+        const storage = new ProjectStorage(filename);
+
+        storage.push("RemoteA", "vscode-remote://ssh-remote+server-A/home/user/project");
+
+        const found = storage.existsRemoteWithRootPath(Uri.parse("vscode-remote://ssh-remote+server-B/home/user/project"));
+
+        assert.strictEqual(found, undefined);
+    });
+
+    test("existsRemoteWithRootPath ignores same authority and path on a different URI scheme", () => {
+        const filename = createTempFilename();
+        const storage = new ProjectStorage(filename);
+
+        storage.push("RemoteProject", "vscode-remote://ssh-remote+server/home/user/project");
+
+        const found = storage.existsRemoteWithRootPath(Uri.parse("vscode-vfs://ssh-remote+server/home/user/project"));
+
+        assert.strictEqual(found, undefined);
     });
 
     test("existsWithRootPath returns expandedHomePath when asked", () => {


### PR DESCRIPTION
## Description
Fixes #927.

Remote project detection now compares both the remote URI authority and path when matching saved Remote SSH projects. This prevents projects on different SSH hosts from being treated as the same current project when they share an identical folder path.

--- 

## Prerequisites Checklist
- [x] The code is **up-to-date with the `master` branch**
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] The code **follows the repository's coding style** (TypeScript conventions, formatting, naming)
- [x] All changes are **testable and have been manually tested**

--- 

## Regular PR

If your PR is a regular PR, to fix an issue, provide a new feature or change a behavior, follow this additional checklist:

- [x] This PR must address an **existing issue**

### Changes Made
- Compare `Uri.authority` along with `Uri.path` in `existsRemoteWithRootPath`.
- Add regression coverage for two Remote SSH projects with the same path on different hosts.
- Add coverage ensuring a same-path project on another remote authority is not matched.

--- 

## Testing
- [x] Tested locally with the extension running in VS Code
- [ ] Tested on Windows (if applicable)
- [x] Tested on macOS (if applicable)
- [ ] Tested on Linux (if applicable)
- [x] Tested on Remotes (Containers, WSL, etc.)
- [x] Verified existing functionality still works (no regressions)

Automated validation run locally:
- `npm run compile`
- `npm run lint` (passes with existing warnings)
- `npm run test-compile`
- `npm test` (62 passing)

## Documentation
- [x] Updated [README.md](../README.md) if adding user-facing features (if applicable)

## Additional Notes
This change is intentionally limited to remote URI matching and does not affect local project path matching.
