### PR TITLE
fix: guard against undefined currentProject in sidebar decoration provider

### DIFF
--- a/src/sidebar/decoration.ts
+++ b/src/sidebar/decoration.ts
@@ -11,7 +11,7 @@ export function registerSideBarDecorations() {
         provideFileDecoration: (uri) => {
             if (uri.scheme !== 'projectManager-view') return undefined;
 
-            if (uri.path === Container.currentProject.rootPath) {
+            if (Container.currentProject && uri.path === Container.currentProject.rootPath) {
                 return {
                     badge: '✔',
                     color: new ThemeColor('projectManager.sideBar.currentProjectHighlightForeground')


### PR DESCRIPTION
## Description

Fixes a crash in the sidebar decoration provider when `Container.currentProject` is `undefined`.

**Root cause:** `Container._currentProject` is declared but never initialized, so it remains `undefined` whenever no saved project matches the currently open folder (e.g. a window opened on a folder not in the Project Manager list, or during startup before the current project is resolved). The `provideFileDecoration` method in `decoration.ts` accessed `.rootPath` on `Container.currentProject` without a null guard, throwing:

```
TypeError: Cannot read properties of undefined (reading 'rootPath')
```

Because `provideFileDecoration` is invoked repeatedly (once per tree item), the errors flood the Extension Host and can cause it to terminate.

**Fix:** Added a truthiness check for `Container.currentProject` before accessing `.rootPath`.

## Changes

- `src/sidebar/decoration.ts`: Guard `Container.currentProject` with a null check before accessing `.rootPath`

## Testing

- [x] Compiles without new errors (pre-existing type errors in other files are unrelated)
- [x] Logic verified: when `currentProject` is undefined, the function returns `undefined` (no decoration), which is the correct fallback behavior

Closes #938

---

_This contribution was created with assistance from an AI coding agent (Buck/OpenClaw). The fix was reviewed and validated for correctness._
