### PR TITLE
Add Folders sidebar view with named groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
 					"name": "%projectManager.views.favorites.name%"
 				},
 				{
+					"id": "projectsExplorerFolders",
+					"name": "%projectManager.views.folders.name%",
+					"when": "projectManager.canShowTreeViewFolders"
+				},
+				{
 					"id": "projectsExplorerGit",
 					"name": "%projectManager.views.git.name%",
 					"when": "projectManager.canShowTreeViewGit"
@@ -228,6 +233,16 @@
 				"icon": "$(refresh)"
 			},
 			{
+				"command": "projectManager.listFolderProjects#sideBarFolders",
+				"title": "%projectManager.commands.listFolderProjects.sideBarFolders.title%",
+				"icon": "$(search)"
+			},
+			{
+				"command": "projectManager.refreshFolders",
+				"title": "%projectManager.commands.refreshFolders.title%",
+				"icon": "$(refresh)"
+			},
+			{
 				"command": "projectManager.listMercurialProjects#sideBarMercurial",
 				"title": "%projectManager.commands.listMercurialProjects#sideBarMercurial.title%",
 				"icon": "$(search)"
@@ -255,6 +270,10 @@
 			{
 				"command": "projectManager.openSettings#sideBarMercurial",
 				"title": "%projectManager.commands.openSettings#sideBarMercurial.title%"
+			},
+			{
+				"command": "projectManager.openSettings#sideBarFolders",
+				"title": "%projectManager.commands.openSettings#sideBarFolders.title%"
 			},
 			{
 				"command": "_projectManager.open",
@@ -332,6 +351,11 @@
 			{
 				"command": "_projectManager.openSideBar",
 				"title": "%projectManager.commands.openSideBar.title%"
+			},
+			{
+				"command": "_projectManager.openFolderGroupInNewWindow",
+				"title": "%projectManager.commands.openFolderGroupInNewWindow.title%",
+				"icon": "$(link-external)"
 			}
 		],
 		"menus": {
@@ -449,6 +473,10 @@
 					"when": "false"
 				},
 				{
+					"command": "projectManager.refreshFolders",
+					"when": "false"
+				},
+				{
 					"command": "_projectManager.whatsNewContextMenu",
 					"when": "false"
 				},
@@ -466,6 +494,18 @@
 				},
 				{
 					"command": "_projectManager.openSideBar",
+					"when": "false"
+				},
+				{
+					"command": "projectManager.listFolderProjects#sideBarFolders",
+					"when": "false"
+				},
+				{
+					"command": "projectManager.openSettings#sideBarFolders",
+					"when": "false"
+				},
+				{
+					"command": "_projectManager.openFolderGroupInNewWindow",
 					"when": "false"
 				}
 			],
@@ -589,37 +629,57 @@
 					"command": "projectManager.openSettings#sideBarMercurial",
 					"when": "view == projectsExplorerMercurial",
 					"group": "2_projectManager"
+				},
+				{
+					"command": "projectManager.listFolderProjects#sideBarFolders",
+					"when": "view == projectsExplorerFolders",
+					"group": "navigation@10"
+				},
+				{
+					"command": "projectManager.refreshFolders",
+					"when": "view == projectsExplorerFolders",
+					"group": "navigation@11"
+				},
+				{
+					"command": "projectManager.openSettings#sideBarFolders",
+					"when": "view == projectsExplorerFolders",
+					"group": "2_projectManager"
 				}
 			],
 			"view/item/context": [
 				{
+					"command": "_projectManager.openFolderGroupInNewWindow",
+					"when": "view == projectsExplorerFolders && viewItem == FolderNodeKind",
+					"group": "navigation"
+				},
+				{
 					"command": "_projectManager.openInNewWindow",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind",
 					"group": "inline"
 				},
 				{
 					"command": "_projectManager.open",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind",
 					"group": "navigation"
 				},
 				{
 					"command": "_projectManager.openInNewWindow",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind",
 					"group": "navigation"
 				},
 				{
 					"command": "_projectManager.revealInFinder#sideBar",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind && isMac",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind && isMac",
 					"group": "navigation@2"
 				},
 				{
 					"command": "_projectManager.revealInExplorer#sideBar",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind && isWindows",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind && isWindows",
 					"group": "navigation@2"
 				},
 				{
 					"command": "_projectManager.revealInFileManager#sideBar",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind && isLinux",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind && isLinux",
 					"group": "navigation@2"
 				},
 				{
@@ -644,7 +704,7 @@
 				},
 				{
 					"command": "projectManager.addToWorkspace#sideBar",
-					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial)/ && viewItem == ProjectNodeKind",
+					"when": "view =~ /projectsExplorer(Favorites|VSCode|Git|SVN|Any|Mercurial|Folders)/ && viewItem == ProjectNodeKind",
 					"group": "workspace"
 				},
 				{
@@ -844,6 +904,46 @@
 							"%projectManager.configuration.tags.collapseItems.enumDescriptions.startCollapsed%"
 						],
 						"description": "%projectManager.configuration.tags.collapseItems.description%"
+					},
+					"projectManager.folders": {
+						"type": "array",
+						"default": [],
+						"description": "%projectManager.configuration.folders.description%",
+						"items": {
+							"type": "object",
+							"required": [
+								"name",
+								"folder"
+							],
+							"additionalProperties": false,
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Display name for this group in the sidebar"
+								},
+								"folder": {
+									"type": "string",
+									"description": "Absolute path of the folder to scan for projects"
+								},
+								"kind": {
+									"type": "string",
+									"enum": [
+										"git",
+										"any",
+										"vscode",
+										"hg",
+										"svn"
+									],
+									"default": "git",
+									"description": "Type of projects to detect (defaults to git)"
+								},
+								"maxDepthRecursion": {
+									"type": "integer",
+									"default": 1,
+									"description": "Max folder depth to scan (defaults to 1)"
+								}
+							}
+						}
 					}
 				}
 			},

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,6 +20,10 @@
     "projectManager.commands.refreshSVNProjects.title": "Project Manager: Refresh SVN Projects",
     "projectManager.commands.refreshAnyProjects.title": "Project Manager: Refresh Any Projects",
     "projectManager.commands.refreshMercurialProjects.title": "Project Manager: Refresh Mercurial Projects",
+    "projectManager.views.folders.name": "Folders",
+    "projectManager.commands.refreshFolders.title": "Project Manager: Refresh Folders",
+    "projectManager.commands.listFolderProjects.sideBarFolders.title": "Project Manager: List Folder Projects",
+    "projectManager.configuration.folders.description": "Define named folder groups shown in the Folders sidebar view. Each group scans its configured path for projects and displays them as a collapsible section.",
     "projectManager.commands.listFavoriteProjects#sideBarFavorites.title": "List Favorite Projects to Open",
     "projectManager.commands.listVSCodeProjects#sideBarVSCode.title": "List VSCode Projects to Open",
     "projectManager.commands.listGitProjects#sideBarGit.title": "List Git Projects to Open",
@@ -32,6 +36,7 @@
     "projectManager.commands.openSettings#sideBarSVN.title": "Open Settings",
     "projectManager.commands.openSettings#sideBarAny.title": "Open Settings",
     "projectManager.commands.openSettings#sideBarMercurial.title": "Open Settings",
+    "projectManager.commands.openSettings#sideBarFolders.title": "Open Settings",
     "projectManager.commands.open.title": "Open",
     "projectManager.commands.openInNewWindow.title": "Open in New Window",
     "projectManager.commands.revealInFinder#sideBar.title": "Reveal in Finder",
@@ -115,5 +120,6 @@
     "projectManager.walkthroughs.exclusiveSideBar.title": "Exclusive Side Bar",
     "projectManager.walkthroughs.exclusiveSideBar.description": "An exclusive Side Bar with everything you need for great productivity.\n[Open Side Bar](command:_projectManager.openSideBar)",
     "projectManager.walkthroughs.workingWithRemotes.title": "Working with Remotes",
-    "projectManager.walkthroughs.workingWithRemotes.description": "The extension support [Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) scenarios, and you may choose how to use it, depending on your needs."
+    "projectManager.walkthroughs.workingWithRemotes.description": "The extension support [Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) scenarios, and you may choose how to use it, depending on your needs.",
+    "projectManager.commands.openFolderGroupInNewWindow.title": "Open in New Window"
 }

--- a/src/autodetect/abstractLocator.ts
+++ b/src/autodetect/abstractLocator.ts
@@ -30,6 +30,7 @@ export class CustomProjectLocator {
     private baseFolders: string[];
     private excludeBaseFoldersFromResults: boolean;
     private supportedFileExtensions: string[] | null;
+    private fixedBaseFolders: string[] | null = null;
 
     constructor(public kind: string, public displayName: string, public repositoryDetector: RepositoryDetector) {
         this.maxDepth = -1;
@@ -278,10 +279,30 @@ export class CustomProjectLocator {
         let refreshedSomething = false;
         let currentValue = null;
 
-        currentValue = config.get<string[]>(this.kind + ".baseFolders");
-        if (!this.arraysAreEquals(this.baseFolders, currentValue)) {
-            this.baseFolders = currentValue;
+        currentValue = config.get("cacheProjectsBetweenSessions", true);
+        if (this.useCachedProjects !== currentValue) {
+            this.useCachedProjects = currentValue;
             refreshedSomething = true;
+        }
+
+        currentValue = config.get("ignoreProjectsWithinProjects", false);
+        if (this.ignoreProjectsWithinProjects !== currentValue) {
+            this.ignoreProjectsWithinProjects = currentValue;
+            refreshedSomething = true;
+        }
+
+        if (this.fixedBaseFolders !== null) {
+             if (!this.arraysAreEquals(this.baseFolders, this.fixedBaseFolders)) {
+                this.baseFolders = this.fixedBaseFolders.slice();
+                refreshedSomething = true;
+            }
+            return refreshedSomething;
+        } else {
+            currentValue = config.get<string[]>(this.kind + ".baseFolders");
+            if (!this.arraysAreEquals(this.baseFolders, currentValue)) {
+                this.baseFolders = currentValue ?? [];
+                refreshedSomething = true;
+            }
         }
 
         currentValue = config.get<string[]>(this.kind + ".ignoredFolders", []);
@@ -299,18 +320,6 @@ export class CustomProjectLocator {
         currentValue = config.get(this.kind + ".maxDepthRecursion", -1);
         if (this.maxDepth !== currentValue) {
             this.maxDepth = currentValue;
-            refreshedSomething = true;
-        }
-
-        currentValue = config.get("cacheProjectsBetweenSessions", true);
-        if (this.useCachedProjects !== currentValue) {
-            this.useCachedProjects = currentValue;
-            refreshedSomething = true;
-        }
-
-        currentValue = config.get("ignoreProjectsWithinProjects", false);
-        if (this.ignoreProjectsWithinProjects !== currentValue) {
-            this.ignoreProjectsWithinProjects = currentValue;
             refreshedSomething = true;
         }
 
@@ -347,6 +356,25 @@ export class CustomProjectLocator {
             }
         }
         return true;
+    }
+
+    public setFixedBaseFolders(folders: string[], maxDepth?: number): void {
+        this.fixedBaseFolders = folders.slice();
+        if (!this.refreshConfig()) return
+
+        if (maxDepth !== undefined) {
+            this.maxDepth = maxDepth;
+        }
+
+        this.alreadyLocated = false;
+        this.projectList = <AutodetectedProjectList>[];
+        this.initializeCfg();
+    }
+
+    public invalidate(): void {
+        this.alreadyLocated = false;
+        this.projectList = <AutodetectedProjectList>[];
+        this.deleteCacheFile();
     }
 
     public deleteCacheFile() {

--- a/src/commands/openSettings.ts
+++ b/src/commands/openSettings.ts
@@ -18,4 +18,5 @@ export function registerOpenSettings() {
     Container.context.subscriptions.push(commands.registerCommand("projectManager.openSettings#sideBarGit", () => openSettings("git")));
     Container.context.subscriptions.push(commands.registerCommand("projectManager.openSettings#sideBarAny", () => openSettings("any")));
     Container.context.subscriptions.push(commands.registerCommand("projectManager.openSettings#sideBarMercurial", () => openSettings("hg")));
+    Container.context.subscriptions.push(commands.registerCommand("projectManager.openSettings#sideBarFolders", () => openSettings("folders")));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import { l10n } from "vscode";
 import { registerWalkthrough } from "./commands/walkthrough";
 import { registerSideBarDecorations } from "./sidebar/decoration";
 import { ProjectNode } from "./sidebar/nodes";
+import type { FolderNode } from "./sidebar/foldersProvider";
 import { Project } from "./core/project";
 
 let locators: Locators;
@@ -99,6 +100,13 @@ export async function activate(context: vscode.ExtensionContext) {
                 () => ({}),  // done
                 () => vscode.window.showInformationMessage(l10n.t("Could not open the project!")));
     });
+    vscode.commands.registerCommand("_projectManager.openFolderGroupInNewWindow", (node: FolderNode) => {
+        const uri = buildProjectUri(node.folderPath);
+        vscode.commands.executeCommand("vscode.openFolder", uri, { forceNewWindow: true })
+            .then(
+                () => ({}),
+                () => vscode.window.showInformationMessage(l10n.t("Could not open the project!")));
+    });
 
     // register commands (here, because it needs to be used right below if an invalid JSON is present)
     vscode.commands.registerCommand("projectManager.saveProject", () => saveProject());
@@ -114,6 +122,11 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("projectManager.listSVNProjects#sideBarSVN", () => listAutoDetectedProjects(locators.svnLocator));
     vscode.commands.registerCommand("projectManager.listMercurialProjects#sideBarMercurial", () => listAutoDetectedProjects(locators.mercurialLocator));
     vscode.commands.registerCommand("projectManager.listAnyProjects#sideBarAny", () => listAutoDetectedProjects(locators.anyLocator));
+    vscode.commands.registerCommand("projectManager.listFolderProjects#sideBarFolders", () => listFolderProjects([...providerManager.foldersProvider.locators.values()]));
+    vscode.commands.registerCommand("projectManager.refreshFolders", () => {
+        providerManager.foldersProvider.rebuild(true);
+        providerManager.foldersProvider.showTreeView();
+    });
 
     // new commands (ActivityBar)
     vscode.commands.registerCommand("projectManager.addToWorkspace#sideBar", (node) => addProjectToWorkspace(node));
@@ -184,6 +197,11 @@ export async function activate(context: vscode.ExtensionContext) {
             cfg.affectsConfiguration("projectManager.ignoreProjectsWithinProjects") || 
             cfg.affectsConfiguration("projectManager.supportSymlinksOnBaseFolders")) {
             refreshProjects();
+        }
+
+        if (cfg.affectsConfiguration("projectManager.folders")) {
+            providerManager.foldersProvider.rebuild();
+            providerManager.refreshStorageTreeView();
         }
 
         if (cfg.affectsConfiguration("workbench.iconTheme")) {
@@ -453,6 +471,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     async function listStorageProjects() {
         const pick = await pickProjects(projectStorage, undefined, true, undefined); 
+        openPickedProject(pick, false, CommandLocation.SideBar);
+    }
+
+    async function listFolderProjects(extraLocators: CustomProjectLocator[]) {
+        const pick = await pickProjects(undefined, locators, true, undefined, extraLocators);
         openPickedProject(pick, false, CommandLocation.SideBar);
     }
 

--- a/src/quickpick/projectsPicker.ts
+++ b/src/quickpick/projectsPicker.ts
@@ -91,8 +91,7 @@ export interface Picked<T> {
     button: QuickInputButton | undefined
 }
 
-export async function pickProjects(projectStorage: ProjectStorage, locators: Locators, showOpenInNewWindowButton: boolean,
-    locatorToFilter: CustomProjectLocator): Promise<Picked<Project> | undefined> {
+export async function pickProjects(projectStorage: ProjectStorage, locators: Locators, showOpenInNewWindowButton: boolean, locatorToFilter: CustomProjectLocator, extraLocators?: CustomProjectLocator[]): Promise<Picked<Project> | undefined> {
     const disposables: Disposable[] = [];
 
     try {
@@ -121,6 +120,13 @@ export async function pickProjects(projectStorage: ProjectStorage, locators: Loc
                 })
                 .then((folders) => {
                     return getProjectsFromLocator(folders, locators, locatorToFilter, locators?.anyLocator);
+                })
+                .then((folders) => {
+                    if (!extraLocators) return folders;
+                    return extraLocators.reduce(
+                        (p, loc) => p.then(f => locators.getLocatorProjects(f, loc)),
+                        Promise.resolve([] as any[])
+                    );
                 })
                 .then((folders) => { // sort
                     if ((<any[]>folders).length === 0) {

--- a/src/sidebar/foldersProvider.ts
+++ b/src/sidebar/foldersProvider.ts
@@ -1,0 +1,127 @@
+import * as vscode from "vscode";
+import { ThemeIcons } from "vscode-ext-codicons";
+import { AutodetectedProjectList, CustomProjectLocator } from "../autodetect/abstractLocator";
+import { GitRepositoryDetector } from "../autodetect/gitRepositoryDetector";
+import { AnyRepositoryDetector } from "../autodetect/anyRepositoryDetector";
+import { VSCodeRepositoryDetector } from "../autodetect/vscodeRepositoryDetector";
+import { MercurialRepositoryDetector } from "../autodetect/mercurialRepositoryDetector";
+import { SvnRepositoryDetector } from "../autodetect/svnRepositoryDetector";
+import { RepositoryDetector } from "../autodetect/repositoryDetector";
+import { ProjectNode } from "./nodes";
+import { addParentFolderToDuplicates } from "../utils/path";
+
+export interface FolderConfig {
+    name: string;
+    folder: string;
+    kind?: string;
+    maxDepthRecursion?: number;
+}
+
+export class FolderNode extends vscode.TreeItem {
+    constructor(public readonly label: string, public readonly folderPath: string) {
+        super(label, vscode.TreeItemCollapsibleState.Collapsed);
+        this.iconPath = ThemeIcons.folder;
+        this.contextValue = "FolderNodeKind";
+    }
+}
+
+function buildDetector(kind: string): RepositoryDetector {
+    switch (kind) {
+        case "any": return new AnyRepositoryDetector([]);
+        case "vscode": return new VSCodeRepositoryDetector();
+        case "hg": return new MercurialRepositoryDetector([".hg"]);
+        case "svn": return new SvnRepositoryDetector([".svn", "pristine"]);
+        default: return new GitRepositoryDetector([".git"]);
+    }
+}
+
+export class FoldersProvider implements vscode.TreeDataProvider<FolderNode | ProjectNode> {
+
+    public readonly onDidChangeTreeData: vscode.Event<FolderNode | ProjectNode | void>;
+    private readonly internalOnDidChangeTreeData = new vscode.EventEmitter<FolderNode | ProjectNode | void>();
+    public locators = new Map<string, CustomProjectLocator>();
+    private pending = new Map<string, Promise<AutodetectedProjectList>>();
+
+    constructor() {
+        this.onDidChangeTreeData = this.internalOnDidChangeTreeData.event;
+        this.rebuild();
+    }
+
+    public rebuild(forceRefresh = false): void {
+        const configs = this.getConfigs();
+        const newLocators = new Map<string, CustomProjectLocator>();
+
+        configs.forEach((cfg, index) => {
+            const kind = cfg.kind ?? "git"
+            const locator = new CustomProjectLocator(
+                `folder_${index}_${cfg.name}_${kind}`,
+                cfg.name,
+                buildDetector(kind)
+            );
+
+            locator.setFixedBaseFolders([cfg.folder], cfg.maxDepthRecursion || 1);
+            if (forceRefresh) locator.invalidate();
+
+            newLocators.set(cfg.name, locator);
+        });
+
+        this.locators = newLocators;
+        this.pending.clear();
+        this.internalOnDidChangeTreeData.fire();
+    }
+
+    public getTreeItem(element: FolderNode | ProjectNode): vscode.TreeItem {
+        return element;
+    }
+
+    public async getChildren(element?: FolderNode | ProjectNode): Promise<(FolderNode | ProjectNode)[]> {
+        if (!element) {
+            return this.getConfigs().map(cfg => new FolderNode(cfg.name, cfg.folder));
+        }
+
+        if (element instanceof FolderNode) {
+            return this.getProjectNodes(element.label as string);
+        }
+
+        return [];
+    }
+
+    public showTreeView(): void {
+        vscode.commands.executeCommand("setContext", "projectManager.canShowTreeViewFolders",
+            this.getConfigs().length > 0);
+    }
+
+    private async getProjectNodes(folderName: string): Promise<ProjectNode[]> {
+        const locator = this.locators.get(folderName);
+        if (!locator) return [];
+
+        let list: AutodetectedProjectList;
+        if (locator.isAlreadyLocated()) {
+            list = locator.projectList;
+        } else {
+            if (!this.pending.has(folderName)) {
+                const scan = locator.locateProjects();
+
+                this.pending.set(folderName, scan);
+                scan.then(() => this.pending.delete(folderName));
+            }
+
+            list = await this.pending.get(folderName)!;
+        }
+
+        if (list.length === 0) return [];
+        list.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+
+        return addParentFolderToDuplicates(list).map(item =>
+            new ProjectNode(item.name, vscode.TreeItemCollapsibleState.None, item.icon,
+                { name: item.name, detail: item.parent, path: item.path },
+                { command: "_projectManager.open", title: "", arguments: [item.path, item.name] }
+            )
+        );
+    }
+
+    private getConfigs(): FolderConfig[] {
+        return vscode.workspace.getConfiguration("projectManager")
+            .get<FolderConfig[]>("folders", []);
+    }
+}

--- a/src/sidebar/providers.ts
+++ b/src/sidebar/providers.ts
@@ -9,6 +9,7 @@ import { ProjectStorage } from "../storage/storage";
 import { ProjectNode, TagNode } from "./nodes";
 import { AutodetectProvider } from "./autodetectProvider";
 import { StorageProvider } from "./storageProvider";
+import { FoldersProvider } from "./foldersProvider";
 import { Container } from "../core/container";
 import { l10n } from "vscode";
 
@@ -20,6 +21,7 @@ export class Providers {
     public mercurialProvider: AutodetectProvider;
     public svnProvider: AutodetectProvider;
     public anyProvider: AutodetectProvider;
+    public foldersProvider: FoldersProvider;
 
     private storageTreeView: vscode.TreeView<ProjectNode | TagNode>;
     private vscodeTreeView: vscode.TreeView<ProjectNode>;
@@ -27,6 +29,7 @@ export class Providers {
     private mercurialTreeView: vscode.TreeView<ProjectNode>;
     private svnTreeView: vscode.TreeView<ProjectNode>;
     private anyTreeView: vscode.TreeView<ProjectNode>;
+    private foldersTreeView: vscode.TreeView<vscode.TreeItem>;
 
     private locators: Locators;
     private projectStorage: ProjectStorage;
@@ -35,6 +38,7 @@ export class Providers {
         this.locators = locators;
         this.projectStorage = storage;
 
+        this.foldersProvider = new FoldersProvider();
         this.storageProvider = new StorageProvider(this.projectStorage);
         this.vscodeProvider = new AutodetectProvider(this.locators.vscLocator);
         this.gitProvider = new AutodetectProvider(this.locators.gitLocator);
@@ -65,6 +69,10 @@ export class Providers {
         this.anyTreeView = vscode.window.createTreeView("projectsExplorerAny", {
             treeDataProvider: this.anyProvider,
             showCollapseAll: false
+        });
+        this.foldersTreeView = vscode.window.createTreeView("projectsExplorerFolders", {
+            treeDataProvider: this.foldersProvider,
+            showCollapseAll: true
         });
 
         this.registerStorageTreeViewListeners();
@@ -100,6 +108,7 @@ export class Providers {
         await this.mercurialProvider.showTreeView();
         await this.svnProvider.showTreeView();
         await this.anyProvider.showTreeView();
+        await this.foldersProvider.showTreeView();
 
         this.updateTreeViewDetails();
     }
@@ -138,5 +147,6 @@ export class Providers {
         this.mercurialTreeView.title = `Mercurial (${this.locators.mercurialLocator.projectList.length})`;
         this.svnTreeView.title = `SVN (${this.locators.svnLocator.projectList.length})`;
         this.anyTreeView.title = `Any (${this.locators.anyLocator.projectList.length})`;
+        this.foldersTreeView.title = "Folders";
     }
 }


### PR DESCRIPTION
## Description

Adds a new **Folders** view to the Project Manager sidebar. Users can define named groups in `projectManager.folders`, each pointing to a folder path that is scanned for projects and displayed as a collapsible section.

This provides a fast, named alternative to the global Git/VSCode/Any views — useful when you want to browse a specific directory (e.g. "Work", "Side Projects") independently, with depth 1 by default.

---

## Prerequisites Checklist
- [x] The code is **up-to-date with the `master` branch**
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] The code **follows the repository's coding style** (TypeScript conventions, formatting, naming)
- [x] All changes are **testable and have been manually tested**

---

## Regular PR

- [ ] This PR must address an **existing issue**

### Changes Made

- New `FoldersProvider` tree data provider with lazy per-group scanning, per-entry `kind` (`git`/`any`/`vscode`/`hg`/`svn`) and `maxDepthRecursion` (default `1`), and isolated per-folder cache files to avoid collision with global locators
- `CustomProjectLocator`: added `setFixedBaseFolders()` and `invalidate()` to support folder-scoped scanning independent of global settings
- `pickProjects`: added optional `extraLocators` parameter so the Folders list command reuses the existing quick-pick machinery without duplication
- Toolbar buttons on the Folders view: List Projects, Refresh, Open Settings
- Context menu on project items: Open, Open in New Window, Reveal in File Manager, Add to Workspace
- Context menu on folder group header: Open in New Window
- `projectManager.folders` config schema with `name`, `folder`, `kind`, and `maxDepthRecursion` per entry

---

## Testing
- [x] Tested locally with the extension running in VS Code
- [x] Tested on Windows
- [ ] Tested on macOS (if applicable)
- [ ] Tested on Linux (if applicable)
- [ ] Tested on Remotes (Containers, WSL, etc.)
- [x] Verified existing functionality still works (no regressions)

## Documentation
- [ ] Updated [README.md](../README.md) if adding user-facing features (if applicable)

## Additional Notes

The Folders view intentionally defaults `maxDepthRecursion` to `1` (unlike the global git locator which defaults to `4`), since named groups are expected to point to a shallow parent directory. Each folder group gets its own isolated cache file (e.g. `projects_cache_git_work.json`) to prevent cache collisions with global locators.

## Screenshots
<img width="1194" height="977" alt="image" src="https://github.com/user-attachments/assets/fa078ab4-5d84-4fc5-9156-897738ab7047" />
