### PR TITLE
feat: add command API for saving projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,19 @@ Here are some of the features that **Project Manager** provides:
 
 ### Save Project
 
-You can save the current folder/workspace as a **Project** at any time. You just need to type its name. 
+You can save the current folder/workspace as a **Project** at any time. You just need to type its name.
+
+Extensions can also save a known project without opening the input box by executing `projectManager.saveProject` with both a project name and an absolute project path:
+
+```ts
+await vscode.commands.executeCommand(
+    "projectManager.saveProject",
+    "My remote project",
+    "/workspace/my-remote-project"
+);
+```
+
+When both arguments are omitted, the command keeps its existing interactive behavior. A programmatic call does not overwrite an existing project with the same name.
 
 ![Save](images/project-manager-save.png)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     // register commands (here, because it needs to be used right below if an invalid JSON is present)
-    vscode.commands.registerCommand("projectManager.saveProject", () => saveProject());
+    vscode.commands.registerCommand("projectManager.saveProject", (projectName?: string, projectPath?: string) => saveProject(undefined, projectName, projectPath));
     vscode.commands.registerCommand("projectManager.refreshProjects", () => refreshProjects(true, true));
     locators.registerCommands();
     vscode.commands.registerCommand("projectManager.editProjects", () => editProjects());
@@ -281,11 +281,21 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     }
 
-    async function saveProject(node?: ProjectNode) {
+    async function saveProject(node?: ProjectNode, commandProjectName?: string, commandProjectPath?: string) {
         let wpath: string;
         let rootPath: string;
+        const hasCommandInvocation = commandProjectName !== undefined || commandProjectPath !== undefined;
+        const hasCommandArguments = typeof commandProjectName === "string" && commandProjectName.trim() !== ""
+            && typeof commandProjectPath === "string" && commandProjectPath.trim() !== "";
 
-        if (node) {
+        if (hasCommandInvocation && !hasCommandArguments) {
+            return false;
+        }
+
+        if (hasCommandArguments) {
+            wpath = commandProjectName;
+            rootPath = commandProjectPath;
+        } else if (node) {
             wpath = node.label as string; 
             rootPath = node.command.arguments[0];
         } else {
@@ -323,6 +333,10 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
                 return true;
             } else {
+                if (hasCommandArguments) {
+                    return false;
+                }
+
                 const optionUpdate = <vscode.MessageItem> {
                     title: l10n.t("Update")
                 };
@@ -356,6 +370,10 @@ export async function activate(context: vscode.ExtensionContext) {
                 return false;
             }
         };
+
+        if (hasCommandArguments) {
+            return saveProjectInternal(wpath);
+        }
 
         const input = vscode.window.createInputBox();
         input.title = l10n.t("Save Project");


### PR DESCRIPTION
## Description

Closes #818.

Adds a programmatic `projectManager.saveProject` command path for extensions that already know the project name and path, such as Remote SSH or WSL workflows. Calling the command without arguments keeps the existing interactive UI unchanged.

## Changes Made

- accept `projectName` and `projectPath` command arguments and save without opening the input box;
- return without overwriting when the name already exists in programmatic mode;
- document the command API and its interactive fallback.

## Testing

- [x] `npm run compile`
- [x] `npm run lint` (existing repository warnings only; no errors)
- [ ] Tested locally with the extension running in VS Code
- [ ] Tested on Windows
- [ ] Tested on macOS
- [ ] Tested on Linux
- [ ] Tested on Remotes (Containers, WSL, etc.)

## Documentation

- [x] Updated README.md with the command API example
