### PR TITLE
Add project name window title variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,14 @@ If you intend to _share_ projects between  **Stable** and **Insider** installati
     "projectManager.showProjectNameInStatusBar": true
 ```
 
+* Display the Project Name in the Window Title (VS Code 1.93 and newer)
+
+Project Manager exposes the `${projectName}` variable for use in the built-in `window.title` setting.
+
+```json
+    "window.title": "${projectName}${separator}${activeEditorShort}"
+```
+
 * Open projects in _New Window_ when clicking in status bar (`false` by default)
 
 ```json 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { registerWalkthrough } from "./commands/walkthrough";
 import { registerSideBarDecorations } from "./sidebar/decoration";
 import { ProjectNode } from "./sidebar/nodes";
 import { Project } from "./core/project";
+import { registerProjectNameWindowTitleVariable, updateProjectNameWindowTitleVariable } from "./utils/windowTitle";
 
 let locators: Locators;
 
@@ -167,6 +168,8 @@ export async function activate(context: vscode.ExtensionContext) {
     // introduce issues.
     const currentProject = showStatusBar(projectStorage, locators);
     Container.currentProject = currentProject;
+    await registerProjectNameWindowTitleVariable();
+    await updateProjectNameWindowTitleVariable(currentProject);
 
     // // new place to register TreeView
     await providerManager.showTreeViewFromAllProviders();
@@ -319,7 +322,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 vscode.window.showInformationMessage(l10n.t("Project saved!"));
                 if (!node) {
                     showStatusBar(projectStorage, locators, projectName);
-                    updateCurrentProject();
+                    await updateCurrentProject();
                 }
                 return true;
             } else {
@@ -426,7 +429,7 @@ export async function activate(context: vscode.ExtensionContext) {
         input.show();
     }
 
-    function updateCurrentProject() {
+    async function updateCurrentProject() {
         const workspace0 = vscode.workspace.workspaceFile ? vscode.workspace.workspaceFile :
             vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[ 0 ].uri :
                 undefined;
@@ -439,6 +442,7 @@ export async function activate(context: vscode.ExtensionContext) {
             foundProject = projectStorage.existsWithRootPath(currentProjectPath, true);
         }
         Container.currentProject = foundProject;
+        await updateProjectNameWindowTitleVariable(foundProject);
     }
 
     async function listProjects(forceNewWindow: boolean) {
@@ -529,7 +533,7 @@ export async function activate(context: vscode.ExtensionContext) {
             value: oldName
         };
 
-        vscode.window.showInputBox(ibo).then(newName => {
+        vscode.window.showInputBox(ibo).then(async newName => {
             if (typeof newName === "undefined" || newName === oldName) {
                 return;
             }
@@ -546,6 +550,10 @@ export async function activate(context: vscode.ExtensionContext) {
                 projectStorage.save();
                 vscode.window.showInformationMessage(l10n.t("Project renamed!"));
                 updateStatusBar(oldName, node.command.arguments[0], newName);
+                if (Container.currentProject?.name.toLowerCase() === oldName.toLowerCase()) {
+                    Container.currentProject.name = newName;
+                    await updateProjectNameWindowTitleVariable(Container.currentProject);
+                }
             } else {
                 vscode.window.showErrorMessage(l10n.t("Project already exists!"));
             }

--- a/src/statusbar/statusBar.ts
+++ b/src/statusbar/statusBar.ts
@@ -26,7 +26,33 @@ export function showStatusBar(projectStorage: ProjectStorage, locators: Locators
             undefined;
     const currentProjectPath = workspace0 ? workspace0.fsPath : undefined;
 
-    if (!showStatusConfig || !currentProjectPath) { return; }
+    if (!currentProjectPath) { return; }
+
+    let foundProject: Project;
+    if (!projectName) {
+        if (isRemoteUri(workspace0)) {
+            foundProject = projectStorage.existsRemoteWithRootPath(workspace0);
+        } else {
+            foundProject = projectStorage.existsWithRootPath(currentProjectPath, true);
+            if (!foundProject) {
+                foundProject = locators.vscLocator.existsWithRootPath(currentProjectPath);
+            }
+            if (!foundProject) {
+                foundProject = locators.gitLocator.existsWithRootPath(currentProjectPath);
+            }
+            if (!foundProject) {
+                foundProject = locators.mercurialLocator.existsWithRootPath(currentProjectPath);
+            }
+            if (!foundProject) {
+                foundProject = locators.svnLocator.existsWithRootPath(currentProjectPath);
+            }
+            if (!foundProject) {
+                foundProject = locators.anyLocator.existsWithRootPath(currentProjectPath);
+            }
+        }
+    }
+
+    if (!showStatusConfig) { return foundProject; }
 
     if (!statusItem) {
         statusItem = window.createStatusBarItem("projectManager.statusBar", StatusBarAlignment.Left);
@@ -42,34 +68,12 @@ export function showStatusBar(projectStorage: ProjectStorage, locators: Locators
         statusItem.command = "projectManager.listProjects";
     }
 
-    // if we have a projectName, we don't need to search.
     if (projectName) {
         statusItem.text += projectName;
         statusItem.show();
         return undefined;
     }
 
-    let foundProject: Project;
-    if (isRemoteUri(workspace0)) {
-        foundProject = projectStorage.existsRemoteWithRootPath(workspace0);
-    } else {
-        foundProject = projectStorage.existsWithRootPath(currentProjectPath, true);
-        if (!foundProject) {
-            foundProject = locators.vscLocator.existsWithRootPath(currentProjectPath);
-        }
-        if (!foundProject) {
-            foundProject = locators.gitLocator.existsWithRootPath(currentProjectPath);
-        }
-        if (!foundProject) {
-            foundProject = locators.mercurialLocator.existsWithRootPath(currentProjectPath);
-        }
-        if (!foundProject) {
-            foundProject = locators.svnLocator.existsWithRootPath(currentProjectPath);
-        }
-        if (!foundProject) {
-            foundProject = locators.anyLocator.existsWithRootPath(currentProjectPath);
-        }
-    }
     if (foundProject) {
         statusItem.text += foundProject.name;
         statusItem.show();

--- a/src/utils/windowTitle.ts
+++ b/src/utils/windowTitle.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { commands } from "vscode";
+import { Project } from "../core/project";
+
+const PROJECT_NAME_CONTEXT_KEY = "projectManager.projectName";
+const REGISTER_WINDOW_TITLE_VARIABLE_COMMAND = "registerWindowTitleVariable";
+
+export async function registerProjectNameWindowTitleVariable(): Promise<void> {
+    const availableCommands = await commands.getCommands();
+    if (!availableCommands.includes(REGISTER_WINDOW_TITLE_VARIABLE_COMMAND)) {
+        return;
+    }
+
+    await commands.executeCommand(
+        REGISTER_WINDOW_TITLE_VARIABLE_COMMAND,
+        "projectName",
+        PROJECT_NAME_CONTEXT_KEY
+    );
+}
+
+export async function updateProjectNameWindowTitleVariable(project?: Project): Promise<void> {
+    await commands.executeCommand("setContext", PROJECT_NAME_CONTEXT_KEY, project?.name);
+}


### PR DESCRIPTION
## Description

Closes #943.

Project Manager now exposes `${projectName}` for the built-in `window.title` setting. The variable is backed by a context key so title updates follow the detected project name, including save and rename flows.

Hosts older than VS Code 1.93 skip window-title registration, preserving the declared VS Code 1.78 compatibility. Current-project detection also remains available when the status bar is disabled.

---

## Prerequisites Checklist

- [x] The code is **up-to-date with the `master` branch**
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] The code **follows the repository's coding style** (TypeScript conventions, formatting, naming)
- [x] All changes are **testable and have been manually tested**

---

## Regular PR

- [x] This PR addresses an **existing issue**

### Changes Made

- register `${projectName}` through `registerWindowTitleVariable` when available;
- keep the project-name context key synchronized with current-project changes;
- detect the current project independently of status-bar visibility;
- document the template and VS Code version requirement.

---

## Testing

- [x] Tested locally with the extension running in VS Code
- [ ] Tested on Windows (if applicable)
- [x] Tested on macOS (if applicable)
- [ ] Tested on Linux (if applicable)
- [ ] Tested on Remotes (Containers, WSL, etc.)
- [x] Verified existing functionality still works (no regressions)

Verification performed:

- `npm run compile`
- `npm run lint` (52 existing warnings, 0 errors)
- `npm run test-compile`
- `npm run vscode:prepublish`
- 63/63 Extension Host integration tests on VS Code 1.128
- 63/63 Extension Host integration tests on VS Code 1.78
- manual failure/success title validation with status-bar display disabled

## Documentation

- [x] Updated [README.md](../README.md) for the user-facing feature

## Additional Notes

No VS Code engine-range or dependency change is included.
