### PR TITLE
feat: show project favicons in the sidebar

### DIFF
--- a/src/sidebar/autodetectProvider.ts
+++ b/src/sidebar/autodetectProvider.ts
@@ -25,7 +25,8 @@ export class AutodetectProvider implements vscode.TreeDataProvider<ProjectNode> 
         this.internalOnDidChangeTreeData.fire();
     }
 
-    public getTreeItem(element: ProjectNode): vscode.TreeItem {
+    public async getTreeItem(element: ProjectNode): Promise<vscode.TreeItem> {
+        await element.resolveFavicon();
         return element;
     }
 

--- a/src/sidebar/nodes.ts
+++ b/src/sidebar/nodes.ts
@@ -5,8 +5,9 @@
 
 import { Command, IconPath, MarkdownString, ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 import { ThemeIcons } from "vscode-ext-codicons";
+import { resolveProjectFavicon } from "../utils/favicon";
 import { currentIconThemeHasFolderIcon, getProjectIcon, getIconDetailsFromProjectPath } from "../utils/icons";
-import { REMOTE_PREFIX, VIRTUAL_WORKSPACE_PREFIX } from "../utils/remote";
+import { isRemotePath, REMOTE_PREFIX, VIRTUAL_WORKSPACE_PREFIX } from "../utils/remote";
 
 export interface ProjectPreview {
     name: string;
@@ -15,6 +16,8 @@ export interface ProjectPreview {
 }
 
 export class ProjectNode extends TreeItem {
+
+    private faviconResolved = false;
 
     constructor(
         public readonly label: string,
@@ -41,6 +44,23 @@ export class ProjectNode extends TreeItem {
         this.tooltip = new MarkdownString(
             `${label}\n\n_${preview.path}_\n\n${tooltipIcon.icon} ${tooltipIcon.title}`, true);
         this.description = preview.detail;
+    }
+
+    public async resolveFavicon(): Promise<void> {
+        if (this.faviconResolved || !this.icon || isRemotePath(this.preview.path) || this.preview.path.toLowerCase().endsWith(".code-workspace")) {
+            return;
+        }
+
+        this.faviconResolved = true;
+
+        try {
+            const faviconPath = await resolveProjectFavicon(this.preview.path);
+            if (faviconPath) {
+                this.iconPath = Uri.file(faviconPath);
+            }
+        } catch {
+            // keep the existing project type icon when the project cannot be read.
+        }
     }
 
     private getIconPath(icon: string, projectPath: string): string | IconPath {

--- a/src/sidebar/storageProvider.ts
+++ b/src/sidebar/storageProvider.ts
@@ -73,7 +73,10 @@ export class StorageProvider implements vscode.TreeDataProvider<ProjectNode | Ta
         this.internalOnDidChangeTreeData.fire();
     }
 
-    public getTreeItem(element: ProjectNode | TagNode): vscode.TreeItem {
+    public async getTreeItem(element: ProjectNode | TagNode): Promise<vscode.TreeItem> {
+        if (element instanceof ProjectNode) {
+            await element.resolveFavicon();
+        }
         return element;
     }
 

--- a/src/test/suite/favicon.test.ts
+++ b/src/test/suite/favicon.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveProjectFavicon } from "../../utils/favicon";
+
+suite("Project favicon resolution", () => {
+    let projectRoot: string;
+
+    setup(async () => {
+        projectRoot = await mkdtemp(join(tmpdir(), "project-manager-favicon-"));
+    });
+
+    teardown(async () => {
+        await rm(projectRoot, { recursive: true, force: true });
+    });
+
+    test("finds a favicon in the project root", async () => {
+        const faviconPath = join(projectRoot, "favicon.svg");
+        await writeFile(faviconPath, "<svg></svg>");
+
+        assert.strictEqual(await resolveProjectFavicon(projectRoot), faviconPath);
+    });
+
+    test("uses candidate priority for direct matches", async () => {
+        const publicDirectory = join(projectRoot, "public");
+        const rootFaviconPath = join(projectRoot, "favicon.png");
+        await mkdir(publicDirectory);
+        await writeFile(rootFaviconPath, "root");
+        await writeFile(join(publicDirectory, "favicon.svg"), "public");
+
+        assert.strictEqual(await resolveProjectFavicon(projectRoot), rootFaviconPath);
+    });
+
+    test("resolves an icon referenced from HTML", async () => {
+        const assetDirectory = join(projectRoot, "public", "assets");
+        const faviconPath = join(assetDirectory, "site-icon.svg");
+        await mkdir(assetDirectory, { recursive: true });
+        await writeFile(join(projectRoot, "index.html"), '<link href="/assets/site-icon.svg?v=2" rel="icon">');
+        await writeFile(faviconPath, "<svg></svg>");
+
+        assert.strictEqual(await resolveProjectFavicon(projectRoot), faviconPath);
+    });
+
+    test("resolves an icon referenced from a route object", async () => {
+        const routeDirectory = join(projectRoot, "app", "routes");
+        const faviconPath = join(projectRoot, "brand.ico");
+        await mkdir(routeDirectory, { recursive: true });
+        await writeFile(join(routeDirectory, "__root.tsx"), '({ href: "/brand.ico", rel: "shortcut icon" })');
+        await writeFile(faviconPath, "icon");
+
+        assert.strictEqual(await resolveProjectFavicon(projectRoot), faviconPath);
+    });
+
+    test("ignores icon references outside the project", async () => {
+        const routeDirectory = join(projectRoot, "app", "routes");
+        await mkdir(routeDirectory, { recursive: true });
+        await writeFile(join(routeDirectory, "__root.tsx"), '({ rel: "icon", href: "../../outside.ico" })');
+
+        assert.strictEqual(await resolveProjectFavicon(projectRoot), null);
+    });
+});

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { readFile, stat } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+const FAVICON_CANDIDATES = [
+    "favicon.svg",
+    "favicon.ico",
+    "favicon.png",
+    "public/favicon.svg",
+    "public/favicon.ico",
+    "public/favicon.png",
+    "app/favicon.ico",
+    "app/favicon.png",
+    "app/icon.svg",
+    "app/icon.png",
+    "app/icon.ico",
+    "src/favicon.ico",
+    "src/favicon.svg",
+    "src/app/favicon.ico",
+    "src/app/icon.svg",
+    "src/app/icon.png",
+    "assets/icon.svg",
+    "assets/icon.png",
+    "assets/logo.svg",
+    "assets/logo.png",
+    ".idea/icon.svg",
+] as const;
+
+const ICON_SOURCE_FILES = [
+    "index.html",
+    "public/index.html",
+    "app/routes/__root.tsx",
+    "src/routes/__root.tsx",
+    "app/root.tsx",
+    "src/root.tsx",
+    "src/index.html",
+] as const;
+
+const HTML_ICON_RE =
+    /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
+
+const OBJECT_ICON_RE =
+    /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+
+function extractIconHref(source: string): string | null {
+    return source.match(HTML_ICON_RE)?.[ 1 ]
+        ?? source.match(OBJECT_ICON_RE)?.[ 1 ]
+        ?? null;
+}
+
+function resolveWithinRoot(workspaceRoot: string, candidate: string): string | null {
+    const input = candidate.trim();
+
+    if (!input || isAbsolute(input)) {
+        return null;
+    }
+
+    const absolutePath = resolve(workspaceRoot, input);
+    const relativePath = relative(workspaceRoot, absolutePath).replace(/\\/g, "/");
+
+    if (
+        !relativePath ||
+        relativePath === "." ||
+        relativePath === ".." ||
+        relativePath.startsWith("../") ||
+        isAbsolute(relativePath)
+    ) {
+        return null;
+    }
+
+    return absolutePath;
+}
+
+async function findFile(workspaceRoot: string, candidates: readonly string[]): Promise<string | null> {
+    for (const candidate of candidates) {
+        const absolutePath = resolveWithinRoot(workspaceRoot, candidate);
+        if (!absolutePath) {
+            continue;
+        }
+
+        try {
+            if ((await stat(absolutePath)).isFile()) {
+                return absolutePath;
+            }
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+                throw error;
+            }
+        }
+    }
+
+    return null;
+}
+
+export async function resolveProjectFavicon(cwd: string): Promise<string | null> {
+    const workspaceRoot = resolve(cwd.trim());
+    const directMatch = await findFile(workspaceRoot, FAVICON_CANDIDATES);
+
+    if (directMatch) {
+        return directMatch;
+    }
+
+    for (const sourceFile of ICON_SOURCE_FILES) {
+        const sourcePath = resolveWithinRoot(workspaceRoot, sourceFile);
+        if (!sourcePath) {
+            continue;
+        }
+
+        let source: string;
+
+        try {
+            source = await readFile(sourcePath, "utf8");
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                continue;
+            }
+            throw error;
+        }
+
+        const href = extractIconHref(source);
+        if (!href) {
+            continue;
+        }
+
+        const cleanHref = href.replace(/^\//, "");
+        const referencedMatch = await findFile(workspaceRoot, [
+            join("public", cleanHref),
+            cleanHref,
+        ]);
+
+        if (referencedMatch) {
+            return referencedMatch;
+        }
+    }
+
+    return null;
+}

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -97,7 +97,12 @@ async function findFile(workspaceRoot: string, candidates: readonly string[]): P
 }
 
 export async function resolveProjectFavicon(cwd: string): Promise<string | null> {
-    const workspaceRoot = resolve(cwd.trim());
+    const trimmed = cwd.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    const workspaceRoot = resolve(trimmed);
     const directMatch = await findFile(workspaceRoot, FAVICON_CANDIDATES);
 
     if (directMatch) {


### PR DESCRIPTION

<img width="379" height="609" alt="image" src="https://github.com/user-attachments/assets/6f0b590f-969e-4bf2-bd9b-39b04982b48b" />

## Description

Adds automatic per-project favicon discovery to the Project Manager sidebar.

Favicons are shown for both saved favorite projects and auto-detected projects. The existing project-type icon remains as a fallback when no favicon is found or the project cannot be read.

Resolves #647.

---

## Prerequisites Checklist

- [x] The code is **up-to-date with the `master` branch**
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] The code **follows the repository's coding style** (TypeScript conventions, formatting, naming)
- [x] All changes are **testable and have been manually tested**

---

## Regular PR

If your PR is a regular PR, to fix an issue, provide a new feature or change a behavior, follow this additional checklist:

- [x] This PR must address an **existing issue** (#647)

### Changes Made

- Added automatic favicon discovery for project directories.
- Added support for common favicon locations, including:
  - Project-root `favicon.svg`, `favicon.ico`, and `favicon.png`
  - Favicons under `public`, `app`, `src`, and `assets`
  - Next.js-style `app/icon.*` files
  - IntelliJ `.idea/icon.svg`
- Added support for resolving favicon references from:
  - HTML `<link rel="icon">` elements
  - HTML `<link rel="shortcut icon">` elements
  - Route/root metadata objects containing `rel` and `href`
- Strips query parameters from referenced favicon paths.
- Ensures referenced favicon paths cannot escape the project directory.
- Resolves favicons lazily when sidebar items are rendered.
- Applies favicon discovery to both Favorites and auto-detected project views.
- Retains existing project-type icons when:
  - No favicon is available
  - The project cannot be read
  - The project is remote
  - The project is a `.code-workspace` file
- Added automated tests covering direct candidates, candidate priority, HTML references, route metadata, query parameters, and path traversal.

---

## Localization PR

Not applicable. This PR does not add or modify user-facing strings.

---

## Testing

- [x] Tested locally with the extension running in VS Code
- [x] Tested on Windows (if applicable)
- [ ] Tested on macOS (if applicable)
- [ ] Tested on Linux (if applicable)
- [x] Tested on Remotes (Containers, WSL, etc.)
- [x] Verified existing functionality still works (no regressions)

Additional validation performed:

- `npm run test-compile` passes.
- `npm run lint` passes with no errors.
- All five favicon resolver tests pass.
- Verified projects without favicons retain their existing sidebar icons.
- Verified remote projects and workspace files retain their existing icons.

## Documentation

- [ ] Updated [README.md](../README.md) if adding user-facing features (if applicable)

## Additional Notes

SVG favicons containing text-based emoji depend on emoji fonts available to VS Code’s Electron/Chromium renderer. Path-based SVGs and rasterized PNG/ICO favicons provide more consistent cross-platform rendering.

The complete Electron test runner could not be launched in the development environment because the downloaded VS Code binary required the unavailable system library `libnspr4.so`. TypeScript compilation, webpack bundling, linting, focused automated tests, and manual Extension Development Host testing completed successfully.
