### PR TITLE
Fix duplicate autodetected projects on overlapping base folders

### DIFF
--- a/src/autodetect/abstractLocator.ts
+++ b/src/autodetect/abstractLocator.ts
@@ -22,6 +22,7 @@ export interface AutodetectedProjectList extends Array<AutodetectedProjectInfo> 
 export class CustomProjectLocator {
 
     public projectList: AutodetectedProjectList = <AutodetectedProjectList> [];
+    private locatedPaths: Set<string> = new Set<string>();
     private maxDepth: number;
     private ignoredFolders: string[];
     private useCachedProjects: boolean;
@@ -87,6 +88,7 @@ export class CustomProjectLocator {
 
     private clearProjectList() {
         this.projectList = [];
+        this.locatedPaths.clear();
     }
 
     private cachedFileIsValid(projectList: AutodetectedProjectList): boolean {
@@ -108,6 +110,8 @@ export class CustomProjectLocator {
                     this.deleteCacheFile();
                     return;
                 }
+                this.locatedPaths = new Set<string>(
+                    this.projectList.map(project => project.fullPath.toLocaleLowerCase()));
                 this.alreadyLocated = true;
             } catch (error) {
                 this.deleteCacheFile();
@@ -192,6 +196,13 @@ export class CustomProjectLocator {
     }
 
     private addToList(projectInfo: AutodetectedProjectInfo) {
+        // Base folders may overlap (e.g. `~/projects` and `~/projects/work`), which makes
+        // the same project be found by more than one walk. Keep only the first occurrence.
+        if (this.locatedPaths.has(projectInfo.fullPath.toLocaleLowerCase())) {
+            return;
+        }
+
+        this.locatedPaths.add(projectInfo.fullPath.toLocaleLowerCase());
         this.projectList.push(projectInfo);
     }
 

--- a/src/autodetect/abstractLocator.ts
+++ b/src/autodetect/abstractLocator.ts
@@ -105,13 +105,16 @@ export class CustomProjectLocator {
         
         if (fs.existsSync(cacheFile)) {
             try {
-                this.projectList = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
-                if (!this.cachedFileIsValid(this.projectList)) {
+                const cachedProjectList: AutodetectedProjectList =
+                    JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+                if (!this.cachedFileIsValid(cachedProjectList)) {
                     this.deleteCacheFile();
                     return;
                 }
-                this.locatedPaths = new Set<string>(
-                    this.projectList.map(project => project.fullPath.toLocaleLowerCase()));
+                // A cache file written before overlapping base folders were de-duplicated may
+                // already contain repeated projects, so rebuild the list through `addToList`.
+                this.clearProjectList();
+                cachedProjectList.forEach(project => this.addToList(project));
                 this.alreadyLocated = true;
             } catch (error) {
                 this.deleteCacheFile();

--- a/src/test/suite/abstractLocator.test.ts
+++ b/src/test/suite/abstractLocator.test.ts
@@ -80,4 +80,31 @@ suite("CustomProjectLocator", () => {
 
         assert.deepStrictEqual(located, [ project ]);
     });
+
+    test("drops duplicates already present in the cache file", async () => {
+        const foo = path.join(testRoot, "foo");
+        const project = createGitRepo(foo, "a-project");
+
+        const config = workspace.getConfiguration("projectManager");
+        await config.update("git.baseFolders", [ foo ], ConfigurationTarget.Global);
+        await config.update("git.maxDepthRecursion", -1, ConfigurationTarget.Global);
+
+        // A cache file written before duplicates were filtered out.
+        const seeder = new CustomProjectLocator("git", "Git", new GitRepositoryDetector([ ".git" ]));
+        const cacheFile = seeder[ "getCacheFile" ]();
+        const duplicated = [
+            { name: "a-project", fullPath: project, icon: "$(git-branch)" },
+            { name: "a-project", fullPath: project, icon: "$(git-branch)" }
+        ];
+        fs.writeFileSync(cacheFile, JSON.stringify(duplicated, null, "\t"), { encoding: "utf8" });
+
+        const locator = new CustomProjectLocator("git", "Git", new GitRepositoryDetector([ ".git" ]));
+        try {
+            assert.strictEqual(locator.isAlreadyLocated(), true);
+            const located = await locator.locateProjects();
+            assert.deepStrictEqual(located.map(item => item.fullPath), [ project ]);
+        } finally {
+            locator.deleteCacheFile();
+        }
+    });
 });

--- a/src/test/suite/abstractLocator.test.ts
+++ b/src/test/suite/abstractLocator.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import fs = require("fs");
+import path = require("path");
+import os = require("os");
+import * as assert from "assert";
+import { ConfigurationTarget, workspace } from "vscode";
+import { CustomProjectLocator } from "../../autodetect/abstractLocator";
+import { GitRepositoryDetector } from "../../autodetect/gitRepositoryDetector";
+
+function createGitRepo(...segments: string[]): string {
+    const repoPath = path.join(...segments);
+    fs.mkdirSync(path.join(repoPath, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repoPath, ".git", "config"), "");
+    return repoPath;
+}
+
+async function locateWith(baseFolders: string[], maxDepthRecursion: number) {
+    const config = workspace.getConfiguration("projectManager");
+    await config.update("git.baseFolders", baseFolders, ConfigurationTarget.Global);
+    await config.update("git.maxDepthRecursion", maxDepthRecursion, ConfigurationTarget.Global);
+
+    const locator = new CustomProjectLocator("git", "Git", new GitRepositoryDetector([ ".git" ]));
+    locator.deleteCacheFile();
+    try {
+        await locator.refreshProjects(true);
+        return locator.projectList.map(project => project.fullPath);
+    } finally {
+        locator.deleteCacheFile();
+    }
+}
+
+suite("CustomProjectLocator", () => {
+    let testRoot: string;
+
+    setup(() => {
+        testRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "abstract-locator-test-")));
+    });
+
+    teardown(async () => {
+        if (fs.existsSync(testRoot)) {
+            fs.rmSync(testRoot, { recursive: true, force: true });
+        }
+
+        const config = workspace.getConfiguration("projectManager");
+        await config.update("git.baseFolders", undefined, ConfigurationTarget.Global);
+        await config.update("git.maxDepthRecursion", undefined, ConfigurationTarget.Global);
+    });
+
+    test("does not duplicate projects when a base folder is nested in another", async () => {
+        const foo = path.join(testRoot, "foo");
+        const foobar = path.join(foo, "bar");
+        const outerProject = createGitRepo(foo, "outer-project");
+        const nestedProject = createGitRepo(foobar, "nested-project");
+
+        const located = await locateWith([ foo, foobar ], -1);
+
+        assert.deepStrictEqual(located.slice().sort(), [ nestedProject, outerProject ].sort());
+    });
+
+    test("keeps projects only reachable through the nested base folder when maxDepthRecursion limits the outer walk", async () => {
+        const foo = path.join(testRoot, "foo");
+        const foobar = path.join(foo, "bar");
+        const outerProject = createGitRepo(foo, "outer-project");
+        const nestedProject = createGitRepo(foobar, "nested-project");
+
+        const located = await locateWith([ foo, foobar ], 1);
+
+        assert.deepStrictEqual(located.slice().sort(), [ nestedProject, outerProject ].sort());
+    });
+
+    test("does not duplicate projects when the same base folder is listed twice", async () => {
+        const foo = path.join(testRoot, "foo");
+        const project = createGitRepo(foo, "a-project");
+
+        const located = await locateWith([ foo, foo ], -1);
+
+        assert.deepStrictEqual(located, [ project ]);
+    });
+});


### PR DESCRIPTION
## Description

Autodetected projects are listed more than once when one configured base folder
is inside another (for example `~/code` and `~/code/nested`).

`CustomProjectLocator.locateProjects` starts an independent `walker` per base
folder, and every walk appends to the same `projectList`, so a project reachable
from two overlapping base folders is added once per walk. All providers that use
`baseFolders` (Git, Mercurial, SVN, VS Code, Any) share this locator and are
affected.

### Relation to #181 and #449

This was reported before and closed as a configuration mistake, so I want to be
upfront.

[#181](https://github.com/alefragnani/vscode-project-manager/issues/181) is
exactly this scenario (`C:\Directory` and `C:\Directory\SubDirectory`), closed
with:

> I don't see the point in adding `C:\Directory` and `C:\Directory\SubDirectory`
> for the same setting, because it detects every subdirectory, for each folder
> that you add. So, in this case, you should simply remove
> `C:\Directory\SubDirectory` from your settings

[#449](https://github.com/alefragnani/vscode-project-manager/issues/449) has the
same explanation ("Unless you have accidentally added a _subfolder_ ... as a
`baseFolder` as well").

That reasoning holds when recursion is unlimited: the outer folder really does
reach everything the nested one would, so the nested entry is pure redundancy.

It stops holding once `maxDepthRecursion` is set. Then the outer walk stops
before the nested folder's contents, and the nested entry is the only thing that
reaches them. Given `~/code/proj-top` and `~/code/nested/proj-deep`, both Git
repos, with `maxDepthRecursion: 1`:

| `git.baseFolders` | detected |
|---|---|
| `["~/code"]` | `proj-top` |
| `["~/code", "~/code/nested"]` | `proj-top`, `nested/proj-deep` |

So "simply remove the subfolder" is not a no-op here. It changes which projects
are detected, dropping `nested/proj-deep` entirely. 

This is what makes the change at least technically relevant rather than a
workaround for a misconfiguration: overlapping base folders are the documented
way to combine a depth limit with deeper detection, and there is currently no
configuration that yields the full set exactly once.

If you would still rather treat overlapping base folders as unsupported, feel
free to close this. But I think the argument is thinner than it was previously
stated, especially given how little logic it adds.

---

## Prerequisites Checklist
- [x] The code is **up-to-date with the `master` branch**
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] The code **follows the repository's coding style** (TypeScript conventions, formatting, naming)
- [x] All changes are **testable and have been manually tested**

---

## Regular PR

- [ ] This PR must address an **existing issue**

CONTRIBUTING.md asks for an issue first. #181 and #449 already cover the
behavior but were closed, so rather than open a third duplicate report I brought
the new argument here. Happy to file a fresh issue if you would prefer this
tracked separately.

### Changes Made

`src/autodetect/abstractLocator.ts`

- Added a `locatedPaths` set tracking full paths already added to `projectList`.
- `addToList` skips a project whose path is already in the set, so a project
  found by more than one walk is kept once. Paths are compared lowercased, to
  match the existing comparison in `existsWithRootPath`.
- `clearProjectList` clears the set with the list, so a refresh starts clean
  instead of discarding every project as an apparent duplicate.
- `initializeCfg` populates the set when `projectList` is restored from the
  cache file, keeping the two in sync on that path too.

`src/test/suite/abstractLocator.test.ts` (new)

- `does not duplicate projects when a base folder is nested in another`
- `keeps projects only reachable through the nested base folder when maxDepthRecursion limits the outer walk` — pins the behavior above
- `does not duplicate projects when the same base folder is listed twice`

---

## Testing
- [x] Tested locally with the extension running in VS Code
- [ ] Tested on Windows (if applicable)
- [x] Tested on macOS (if applicable)
- [ ] Tested on Linux (if applicable)
- [ ] Tested on Remotes (Containers, WSL, etc.)
- [x] Verified existing functionality still works (no regressions)

`npm test` on macOS: 66 passing, 0 failing (63 before this PR, plus the 3 added).

To confirm the new tests actually cover the change, I reverted the
de-duplication guard and re-ran: the two duplication tests fail and the
`maxDepthRecursion` test still passes, which is the expected split.

Not verified on Windows or Linux. The change is plain path-string comparison
with no platform-specific behavior, but the lowercased comparison is the part
most worth a second look on a case-sensitive filesystem.

## Documentation
- [ ] Updated [README.md](../README.md) if adding user-facing features (if applicable)

Not applicable.

## Additional Notes

The fix sits where results are collected, so it covers any overlapping
arrangement: the same folder listed twice, three or more nested levels, and
overlap produced by glob expansion.
