### PR TITLE
Fix Extension Host crash when there is no current project

### DIFF
--- a/src/test/suite/decoration.test.ts
+++ b/src/test/suite/decoration.test.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import { CancellationTokenSource, Disposable, FileDecoration, FileDecorationProvider, Uri, window } from "vscode";
+import { Container } from "../../core/container";
+import { createProject } from "../../core/project";
+import { registerSideBarDecorations } from "../../sidebar/decoration";
+
+// Intercepts the registration so the tests run against the provider the extension
+// actually registers, instead of a copy of it that could drift from the real one.
+function captureRegisteredProvider(): FileDecorationProvider {
+
+    const windowApi = window as unknown as {
+        registerFileDecorationProvider: (provider: FileDecorationProvider) => Disposable
+    };
+    const originalRegister = windowApi.registerFileDecorationProvider;
+
+    let captured: FileDecorationProvider;
+    windowApi.registerFileDecorationProvider = (provider: FileDecorationProvider) => {
+        captured = provider;
+        return { dispose: () => undefined } as Disposable;
+    };
+
+    try {
+        registerSideBarDecorations();
+    } finally {
+        windowApi.registerFileDecorationProvider = originalRegister;
+    }
+
+    return captured;
+}
+
+suite("SideBar Decoration Tests", () => {
+
+    const projectPath = "/home/user/projects/my-project";
+
+    let provider: FileDecorationProvider;
+    let tokenSource: CancellationTokenSource;
+
+    setup(() => {
+        provider = captureRegisteredProvider();
+        tokenSource = new CancellationTokenSource();
+    });
+
+    teardown(() => {
+        tokenSource.dispose();
+        Container.currentProject = undefined;
+    });
+
+    test("should not decorate uris from other schemes", () => {
+        Container.currentProject = createProject("my-project", projectPath);
+
+        const decoration = provider.provideFileDecoration(Uri.file(projectPath), tokenSource.token);
+
+        assert.equal(decoration, undefined);
+    });
+
+    test("should decorate the current project", () => {
+        Container.currentProject = createProject("my-project", projectPath);
+
+        const decoration = provider.provideFileDecoration(
+            Uri.parse(`projectManager-view:${projectPath}`), tokenSource.token) as FileDecoration;
+
+        assert.equal(decoration.badge, "✔");
+    });
+
+    test("should not decorate a project which is not the current one", () => {
+        Container.currentProject = createProject("my-project", projectPath);
+
+        const decoration = provider.provideFileDecoration(
+            Uri.parse("projectManager-view:/home/user/projects/another-project"), tokenSource.token);
+
+        assert.equal(decoration, undefined);
+    });
+
+    test("should not throw when there is no current project", () => {
+        Container.currentProject = undefined;
+
+        assert.doesNotThrow(() => provider.provideFileDecoration(
+            Uri.parse(`projectManager-view:${projectPath}`), tokenSource.token));
+    });
+
+    test("should not decorate when there is no current project", () => {
+        Container.currentProject = undefined;
+
+        const decoration = provider.provideFileDecoration(
+            Uri.parse(`projectManager-view:${projectPath}`), tokenSource.token);
+
+        assert.equal(decoration, undefined);
+    });
+});


### PR DESCRIPTION
## Description

The side bar decoration provider dereferences `Container.currentProject` without checking it, so it throws `Cannot read properties of undefined (reading 'rootPath')` whenever no current project is set. It runs once per tree item, so the errors flood the Extension Host until it terminates and Extension Bisect kicks in.

Fixes https://github.com/alefragnani/vscode-project-manager/issues/938

`Container._currentProject` is declared but never initialized, and is only assigned from `showStatusBar`, which returns no value in four cases. Only the last needs an unmanaged folder:

- `projectManager.showProjectNameInStatusBar` is `false`, so it never resolves even when the folder *is* a saved project
- no folder open (empty window)
- called with an explicit `projectName`
- no project matches the open folder

`strictNullChecks` is not enabled, so typing the getter `Project | undefined` would not be enforced at the call site. The runtime guard is what fixes it.

---

## Prerequisites Checklist
- [x] The code is **up-to-date with the `master` branch**
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] The code **follows the repository's coding style** (TypeScript conventions, formatting, naming)
- [x] All changes are **testable and have been manually tested**

---

## Regular PR

- [x] This PR must address an **existing issue**

### Changes Made

- Guard `Container.currentProject` before comparing its root path, as suggested in the issue.
- Add `SideBar Decoration Tests` covering the unset current project plus existing behavior (current project decorated, others not, foreign schemes ignored). They intercept `window.registerFileDecorationProvider` to exercise the provider the extension actually registers, not a copy that could drift.

---

## Testing

- [x] Tested locally with the extension running in VS Code
- [ ] Tested on Windows (if applicable)
- [x] Tested on macOS (if applicable)
- [ ] Tested on Linux (if applicable)
- [ ] Tested on Remotes (Containers, WSL, etc.)
- [x] Verified existing functionality still works (no regressions)

`npm test` launches a real VS Code 1.130.0 via `@vscode/test-electron`. Not run on Windows, Linux or Remotes; the change is platform independent and does not touch the remote path.

The two new tests fail on `master` and pass with the fix. The pre-fix failure comes from the product file `out/src/sidebar/decoration.js:15`, matching the stack in the issue.

<details>
<summary>Raw logs: before the fix (2 failing)</summary>

```console
$ git stash && npm test
  SideBar Decoration Tests
    ✔ should not decorate uris from other schemes
    ✔ should decorate the current project
    ✔ should not decorate a project which is not the current one
    1) should not throw when there is no current project
    2) should not decorate when there is no current project

  66 passing (2s)
  2 failing

  1) SideBar Decoration Tests
       should not throw when there is no current project:
     AssertionError [ERR_ASSERTION]: Got unwanted exception.
     Actual message: "Cannot read properties of undefined (reading 'rootPath')"
      at Context.<anonymous> (out/src/test/suite/decoration.test.js:59:16)

  2) SideBar Decoration Tests
       should not decorate when there is no current project:
     TypeError: Cannot read properties of undefined (reading 'rootPath')
      at Object.provideFileDecoration (out/src/sidebar/decoration.js:15:67)
      at Context.<anonymous> (out/src/test/suite/decoration.test.js:63:37)

Error: 2 tests failed.
Exit code:   1
```
</details>

<details>
<summary>Raw logs: after the fix (68 passing)</summary>

```console
$ npm test
  SideBar Decoration Tests
    ✔ should not decorate uris from other schemes
    ✔ should decorate the current project
    ✔ should not decorate a project which is not the current one
    ✔ should not throw when there is no current project
    ✔ should not decorate when there is no current project

  68 passing (2s)
[main 2026-07-28T22:53:16.123Z] Extension host with pid 39824 exited with code: 0, signal: unknown.
Exit code:   0
```
</details>

<details>
<summary>Raw logs: Extension Host renderer log, same file across both runs</summary>

```console
$ grep -c "reading 'rootPath'" .vscode-test/user-data/logs/<run>/window1/renderer.log
before the fix   20260728T155222 -> 2
after the fix    20260728T155309 -> 0
```
</details>

`npm run lint` reports 0 errors; the changed files add no new warnings.

## Documentation
- [ ] Updated [README.md](../README.md) if adding user-facing features (if applicable)

Not applicable. This is a crash fix with no user-facing surface change.

## Additional Notes

The guard is deliberately minimal, matching the suggestion in the issue. The other option, an `undefined`-typed getter checked at the call site, only holds once `strictNullChecks` is enabled.
