### PR TITLE
fix(extension): guard dismissed save-project confirmation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,28 +332,24 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 const option = await vscode.window.showInformationMessage(l10n.t("Project already exists!"), optionUpdate, optionCancel);
 
-                // nothing selected or canceled
-                if (typeof option === "undefined" || option.title === l10n.t("Cancel")) {
+                // Only proceed when the user explicitly chose "Update".
+                // Cancel/close (option === undefined) bypasses any field access.
+                if (option?.title !== optionUpdate.title) {
                     return false;
                 }
-
-                if (option.title === l10n.t("Update")) {
-                    Container.stack.push(projectName);
-                    context.globalState.update("recent", Container.stack.toString());
-                    projectStorage.updateRootPath(projectName, rootPath);
-                    if (tagsToSave) {
-                        projectStorage.editTags(projectName, tagsToSave);
-                    }
-                    projectStorage.save();
-                    providerManager.updateTreeViewStorage();
-                    vscode.window.showInformationMessage(l10n.t("Project saved!"));
-                    if (!node) {
-                        showStatusBar(projectStorage, locators, projectName);
-                    }
-                    return true;
+                Container.stack.push(projectName);
+                context.globalState.update("recent", Container.stack.toString());
+                projectStorage.updateRootPath(projectName, rootPath);
+                if (tagsToSave) {
+                    projectStorage.editTags(projectName, tagsToSave);
                 }
-
-                return false;
+                projectStorage.save();
+                providerManager.updateTreeViewStorage();
+                vscode.window.showInformationMessage(l10n.t("Project saved!"));
+                if (!node) {
+                    showStatusBar(projectStorage, locators, projectName);
+                }
+                return true;
             }
         };
 


### PR DESCRIPTION
## Summary
- guard the `saveProject` exists-branch confirmation result with optional chaining
- return cleanly when the user cancels or closes the dialog

## Validation
- `npm run compile`
- `npm run lint`
- `git diff --check`

`npm test` remains environment-blocked because the VS Code Electron binary cannot spawn in this environment.