### PR TITLE
fix: harden Linux projects.json persistence (XDG-aware fallback + migration)

### DIFF
--- a/src/test/suite/path.test.ts
+++ b/src/test/suite/path.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the GPLv3 License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import * as path from "path";
+import { getLinuxConfigFilePath } from "../../utils/path";
+
+suite("PathUtils", () => {
+    test("uses XDG_CONFIG_HOME for Linux project files when configured", () => {
+        const result = getLinuxConfigFilePath("projects.json", "Code", "/home/tester", "/tmp/xdg-config");
+
+        assert.strictEqual(result, path.join("/tmp/xdg-config", "Code", "User", "projects.json"));
+    });
+
+    test("falls back to the user's .config directory", () => {
+        const result = getLinuxConfigFilePath("projects.json", "Code", "/home/tester");
+
+        assert.strictEqual(result, path.join("/home/tester", ".config", "Code", "User", "projects.json"));
+    });
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -18,6 +18,30 @@ export const homeDir = os.homedir();
 export const HOME_PATH_VARIABLE = "$home";
 export const HOME_PATH_TILDE = "~";
 
+export function getLinuxConfigFilePath(file: string, channelPath: string, homePath: string, xdgConfigHome?: string): string {
+    const configHome = xdgConfigHome || path.join(homePath, ".config");
+    return path.join(configHome, channelPath, "User", file);
+}
+
+function ensureParentDirectory(filePath: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function migrateFile(sourcePath: string, targetPath: string): boolean {
+    if (!fs.existsSync(sourcePath) || fs.existsSync(targetPath)) {
+        return false;
+    }
+
+    try {
+        ensureParentDirectory(targetPath);
+        fs.copyFileSync(sourcePath, targetPath);
+        return true;
+    } catch (error) {
+        console.warn(`Could not migrate ${sourcePath} to ${targetPath}:`, error);
+        return false;
+    }
+}
+
 // Contains recommended global storage path if provided by current version of VS Code. 
 let extensionStoragePath = "";
 
@@ -166,13 +190,15 @@ export class PathUtils {
         if (process.env.VSCODE_PORTABLE) {
             appdata = process.env.VSCODE_PORTABLE;
             newFile = path.join(appdata, channelPath, "User", file);
+        } else if (process.platform === "linux") {
+            const legacyFile = path.join("/var/local", channelPath, "User", file);
+            newFile = getLinuxConfigFilePath(file, channelPath, homeDir, process.env.XDG_CONFIG_HOME);
+
+            // Keep existing favorites available when moving away from the old, usually unwritable path.
+            migrateFile(legacyFile, newFile);
         } else {
             appdata = process.env.APPDATA || (process.platform === "darwin" ? process.env.HOME + "/Library/Application Support" : "/var/local");
             newFile = path.join(appdata, channelPath, "User", file);
-            // in linux, it may not work with /var/local, then try to use /home/myuser/.config
-            if ((process.platform === "linux") && (!fs.existsSync(newFile))) {
-                newFile = path.join(homeDir, ".config/", channelPath, "User", file);
-            }
         }
         // If we are on a new version of VS Code, use the specified
         // global extension storage path unless a file exists in 
@@ -181,6 +207,10 @@ export class PathUtils {
             if (!fs.existsSync(newFile)) {
                 newFile = path.join(extensionStoragePath, file);
             }
+        }
+
+        if (!fs.existsSync(newFile)) {
+            ensureParentDirectory(newFile);
         }
         return newFile;
     }


### PR DESCRIPTION
## Description

Fixes #977.

On Linux, resolve the project file under `XDG_CONFIG_HOME` (or `~/.config`) instead of relying on the legacy `/var/local` fallback. Create the parent directory before the first save and copy an existing legacy `projects.json` into the new location so saved favorites remain available. Existing portable, Windows, macOS, and VS Code global-storage behavior remains intact.

## Testing

- `npm test` (87 passing)
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
