### PR TITLE
fix(storage): back up a corrupt projects.json before it can be overwritten

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -167,7 +167,25 @@ export class ProjectStorage {
             return "";
         } catch (error) {
             console.log(error);
+            this.backupCorruptFile();
             return error.toString();
+        }
+    }
+
+    /**
+     * Keeps a timestamped copy of a projects.json that failed to parse, so a
+     * later `save()` (triggered by the user adding or editing projects in the
+     * same session) cannot destroy the original content, which may still be
+     * recoverable by hand.
+     */
+    private backupCorruptFile() {
+        try {
+            if (!fs.existsSync(this.filename)) {
+                return;
+            }
+            fs.copyFileSync(this.filename, `${this.filename}.corrupt-${Date.now()}.bak`);
+        } catch (backupError) {
+            console.log(backupError);
         }
     }
 

--- a/src/test/suite/storage.test.ts
+++ b/src/test/suite/storage.test.ts
@@ -214,6 +214,25 @@ suite("ProjectStorage", () => {
         assert.strictEqual(mapped[0].label, "V1Project1");
 
         fs.unlinkSync(filename);
+
+    test("load backs up a corrupt projects file before reporting the error", () => {
+        const filename = createTempFilename("project-manager-storage-corrupt-");
+        fs.writeFileSync(filename, "{ this is not valid json ]");
+        const storage = new ProjectStorage(filename);
+
+        const error = storage.load();
+
+        assert.notStrictEqual(error, "", "load should report the parse error");
+        const backup = fs
+            .readdirSync(path.dirname(filename))
+            .find((file) => file.startsWith(path.basename(filename) + ".corrupt-") && file.endsWith(".bak"));
+        assert.ok(backup, "a timestamped backup of the corrupt file must exist");
+        assert.strictEqual(
+            fs.readFileSync(path.join(path.dirname(filename), backup!), "utf-8"),
+            "{ this is not valid json ]",
+            "backup must preserve the original corrupt content"
+        );
+    });
     });
 
     test("existsRemoteWithRootPath returns matching project for remote URI", () => {


### PR DESCRIPTION
## What changed
- `ProjectStorage.load()` now makes a best-effort copy of an unparsable `projects.json` to `<filename>.corrupt-<timestamp>.bak` before returning the parse error
- new unit test: a corrupt file yields the error string **and** a timestamped backup preserving the original bytes

## Why
When `projects.json` fails to parse, `load()` logs the error and shows the modal, but the unparsable file is left in place. The first `save()` in the same session (e.g. the user adds a project after reopening) then overwrites it — destroying content that may still be recoverable by hand. The backup keeps that recovery path open at negligible cost.